### PR TITLE
タスク表を複数の完了ステータスに対応

### DIFF
--- a/SinfoniaOperator/SinfoniaOperator/NotionEnvironment.cs
+++ b/SinfoniaOperator/SinfoniaOperator/NotionEnvironment.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text;
 
 namespace SinfoniaStudio.SinfoniaOperator
@@ -40,7 +41,7 @@ namespace SinfoniaStudio.SinfoniaOperator
             DatePropertyName = datePropertyName;
             NamePropertyName = namePropertyName;
             StatusPropertyName = statusPropertyName;
-            TaskDoneStatusName = taskDoneStatusName;
+            TaskDoneStatusName = GetTaskDoneStatuses(taskDoneStatusName);
         }
 
         public readonly string NotionToken;
@@ -49,7 +50,7 @@ namespace SinfoniaStudio.SinfoniaOperator
         public readonly string DatePropertyName;
         public readonly string NamePropertyName;
         public readonly string StatusPropertyName;
-        public readonly string TaskDoneStatusName;
+        public readonly string[] TaskDoneStatusName;
 
         public override string ToString()
         {
@@ -62,6 +63,11 @@ namespace SinfoniaStudio.SinfoniaOperator
             sb.AppendLine($"StatusPropertyName: {StatusPropertyName}");
             sb.AppendLine($"TaskDoneStatusName: {TaskDoneStatusName}");
             return sb.ToString();
+        }
+
+        private string[] GetTaskDoneStatuses(string value)
+        {
+            return value.Split(',').Select(s => s.Trim()).ToArray();
         }
     }
 }

--- a/SinfoniaOperator/SinfoniaOperator/NotionTaskListReader.cs
+++ b/SinfoniaOperator/SinfoniaOperator/NotionTaskListReader.cs
@@ -67,10 +67,11 @@ namespace SinfoniaStudio.SinfoniaOperator
                         continue;
                     }
 
+                    string status = statusProperty.Status.Name;
                     // ステータスが完了済みなら終了。
-                    if (statusProperty.Status.Name == _env.TaskDoneStatusName)
+                    if (_env.TaskDoneStatusName.Contains(status))
                     {
-                        Console.WriteLine($"[TaskReader] {pageName}: ステータスが完了済みのためスキップします。");
+                        Console.WriteLine($"[TaskReader] {pageName}: ステータスが{status}のためスキップします。");
                         continue;
                     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 完了済みタスクのステータスを複数指定できるようになりました。カンマ区切りで複数のステータス名を設定することで、指定されたステータスのいずれかに該当するタスクを完了済みとして処理します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->