### PR TITLE
アウトゲームの簡易的な画面遷移の実装。

### DIFF
--- a/Assets/Level/Scenes/Develop/OutGameTest.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1fa5ddfe775039c439caea6a707f38e7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e422e288d0bc3ae45a99d50867a70c57
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenRuleData.asset
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenRuleData.asset
@@ -13,9 +13,12 @@ MonoBehaviour:
   m_Name: ScreenRuleData
   m_EditorClassIdentifier: KillChord.Structure::KillChord.Runtime.InfraStructure.OutGame.Screen.ScreenRuleData
   _entries:
-  - _screenId: 1
+  - _screenId: 0
     _transitionType: 2
     _isAddToHistory: 0
+  - _screenId: 1
+    _transitionType: 0
+    _isAddToHistory: 1
   - _screenId: 2
     _transitionType: 0
     _isAddToHistory: 1
@@ -23,8 +26,5 @@ MonoBehaviour:
     _transitionType: 0
     _isAddToHistory: 1
   - _screenId: 4
-    _transitionType: 0
-    _isAddToHistory: 1
-  - _screenId: 5
     _transitionType: 1
     _isAddToHistory: 1

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenRuleData.asset
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenRuleData.asset
@@ -1,0 +1,30 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41cad7e54781c7345972795165c96e61, type: 3}
+  m_Name: ScreenRuleData
+  m_EditorClassIdentifier: KillChord.Structure::KillChord.Runtime.InfraStructure.OutGame.Screen.ScreenRuleData
+  _entries:
+  - _screenId: 1
+    _transitionType: 2
+    _isAddToHistory: 0
+  - _screenId: 2
+    _transitionType: 0
+    _isAddToHistory: 1
+  - _screenId: 3
+    _transitionType: 0
+    _isAddToHistory: 1
+  - _screenId: 4
+    _transitionType: 0
+    _isAddToHistory: 1
+  - _screenId: 5
+    _transitionType: 1
+    _isAddToHistory: 1

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenRuleData.asset.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenRuleData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed3d6973f36d66844852d3391a8a18df
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity
@@ -1,0 +1,391 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 10
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 20201, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 3
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    buildHeightMesh: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &203844586
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 203844589}
+  - component: {fileID: 203844588}
+  - component: {fileID: 203844587}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &203844587
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203844586}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UsePipelineSettings: 1
+  m_AdditionalLightsShadowResolutionTier: 2
+  m_CustomShadowLayers: 0
+  m_LightCookieSize: {x: 1, y: 1}
+  m_LightCookieOffset: {x: 0, y: 0}
+  m_SoftShadowQuality: 0
+  m_RenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_ShadowRenderingLayersMask:
+    serializedVersion: 0
+    m_Bits: 1
+  m_Version: 4
+  m_LightLayerMask: 1
+  m_ShadowLayerMask: 1
+  m_RenderingLayers: 1
+  m_ShadowRenderingLayers: 1
+--- !u!108 &203844588
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203844586}
+  m_Enabled: 1
+  serializedVersion: 12
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize2D: {x: 10, y: 10}
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ForceVisible: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+  m_LightUnit: 1
+  m_LuxAtDistance: 1
+  m_EnableSpotReflector: 1
+--- !u!4 &203844589
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 203844586}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &961739749
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 961739753}
+  - component: {fileID: 961739752}
+  - component: {fileID: 961739751}
+  - component: {fileID: 961739750}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &961739750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961739749}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+  m_Version: 2
+--- !u!81 &961739751
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961739749}
+  m_Enabled: 1
+--- !u!20 &961739752
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961739749}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_Iso: 200
+  m_ShutterSpeed: 0.005
+  m_Aperture: 16
+  m_FocusDistance: 10
+  m_FocalLength: 50
+  m_BladeCount: 5
+  m_Curvature: {x: 2, y: 11}
+  m_BarrelClipping: 0.25
+  m_Anamorphism: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &961739753
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 961739749}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1660057539 &9223372036854775807
+SceneRoots:
+  m_ObjectHideFlags: 0
+  m_Roots:
+  - {fileID: 961739753}
+  - {fileID: 203844589}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity
@@ -246,6 +246,61 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &452244043
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 452244045}
+  - component: {fileID: 452244044}
+  m_Layer: 5
+  m_Name: UIDocument
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &452244044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452244043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 19102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.dll::UnityEngine.UIElements.UIDocument
+  m_PanelSettings: {fileID: 11400000, guid: d4e4fe4e5d360ff4b8bcca8857dd62e9, type: 2}
+  m_ParentUI: {fileID: 0}
+  sourceAsset: {fileID: 0}
+  m_SortingOrder: 0
+  m_Position: 0
+  m_WorldSpaceSizeMode: 1
+  m_WorldSpaceWidth: 1920
+  m_WorldSpaceHeight: 1080
+  m_PivotReferenceSize: 0
+  m_Pivot: 0
+  m_WorldSpaceCollider: {fileID: 0}
+--- !u!4 &452244045
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 452244043}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &961739749
 GameObject:
   m_ObjectHideFlags: 0
@@ -389,3 +444,4 @@ SceneRoots:
   m_Roots:
   - {fileID: 961739753}
   - {fileID: 203844589}
+  - {fileID: 452244045}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity
@@ -301,6 +301,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &459519247
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 459519249}
+  - component: {fileID: 459519248}
+  m_Layer: 0
+  m_Name: OutGameUIEvent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &459519248
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 459519247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fbd60ffeeebe9343aed807180f93228, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: KillChord.View::KillChord.Runtime.View.OutGame.Screen.OutGameUIEvent
+--- !u!4 &459519249
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 459519247}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -20.3799, y: 0, z: 74.93372}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &961739749
 GameObject:
   m_ObjectHideFlags: 0
@@ -438,6 +482,52 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1370918365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1370918367}
+  - component: {fileID: 1370918366}
+  m_Layer: 0
+  m_Name: ScreenTransitionInitializer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1370918366
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370918365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2b280857c6f6da49a9e45994f548fc0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: KillChord.Composition::KillChord.Runtime.Composition.OutGame.Screen.ScreenInitializer
+  _uiDocument: {fileID: 452244044}
+  _screenRuleData: {fileID: 11400000, guid: ed3d6973f36d66844852d3391a8a18df, type: 2}
+--- !u!4 &1370918367
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370918365}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -20.3799, y: 0, z: 74.93372}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -445,3 +535,5 @@ SceneRoots:
   - {fileID: 961739753}
   - {fileID: 203844589}
   - {fileID: 452244045}
+  - {fileID: 1370918367}
+  - {fileID: 459519249}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity
@@ -277,7 +277,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: UnityEngine.dll::UnityEngine.UIElements.UIDocument
   m_PanelSettings: {fileID: 11400000, guid: d4e4fe4e5d360ff4b8bcca8857dd62e9, type: 2}
   m_ParentUI: {fileID: 0}
-  sourceAsset: {fileID: 0}
+  sourceAsset: {fileID: 9197481963319205126, guid: e59e88499d314f84aac92e44c089c1c4, type: 3}
   m_SortingOrder: 0
   m_Position: 0
   m_WorldSpaceSizeMode: 1

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/ScreenTransitionTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 78ac1a69576edac4cb2b1143b876b182
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ca422c471454aa240944e613a3743193
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Home.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Home.uxml
@@ -1,7 +1,7 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
     <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
-    <ui:VisualElement class="screen-visible screen-hidden">
+    <ui:VisualElement class="screen-visible">
         <ui:VisualElement name="ButtonRoot" style="flex-grow: 1; justify-content: flex-start; align-items: flex-end; padding-right: 50px; padding-top: 50px; flex-direction: column;">
             <ui:Button text="作戦" name="StageSelect" class="button" style="color: rgb(210, 210, 210); display: flex; opacity: 1;"/>
             <ui:Button text="研究" name="SkillTree" class="button" style="height: 100px; width: 200px; -unity-text-align: middle-center; font-size: 36px; -unity-font-style: bold; background-color: rgba(255, 255, 255, 0); color: rgb(209, 209, 209); display: flex; opacity: 1;"/>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Home.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Home.uxml
@@ -1,11 +1,11 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
     <ui:VisualElement class="screen-visible screen-hidden">
         <ui:VisualElement name="ButtonRoot" style="flex-grow: 1; justify-content: flex-start; align-items: flex-end; padding-right: 50px; padding-top: 50px; flex-direction: column;">
             <ui:Button text="作戦" name="StageSelect" class="button" style="color: rgb(210, 210, 210); display: flex; opacity: 1;"/>
             <ui:Button text="研究" name="SkillTree" class="button" style="height: 100px; width: 200px; -unity-text-align: middle-center; font-size: 36px; -unity-font-style: bold; background-color: rgba(255, 255, 255, 0); color: rgb(209, 209, 209); display: flex; opacity: 1;"/>
-            <ui:Button text="改造" name="SkillSelect" class="button" style="height: 100px; width: 200px; -unity-text-align: middle-center; font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); color: rgb(210, 210, 210); display: flex; opacity: 1;"/>
+            <ui:Button text="改造" name="SkillBuild" class="button" style="height: 100px; width: 200px; -unity-text-align: middle-center; font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); color: rgb(210, 210, 210); display: flex; opacity: 1;"/>
             <ui:Button text="設定" name="Setting" class="button" style="height: 100px; width: 200px; -unity-text-align: middle-center; font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); color: rgb(210, 210, 210); display: flex; opacity: 1;"/>
         </ui:VisualElement>
     </ui:VisualElement>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Home.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Home.uxml
@@ -1,0 +1,12 @@
+<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <ui:VisualElement class="screen-visible screen-hidden">
+        <ui:VisualElement name="ButtonRoot" style="flex-grow: 1; justify-content: flex-start; align-items: flex-end; padding-right: 50px; padding-top: 50px; flex-direction: column;">
+            <ui:Button text="作戦" name="StageSelect" class="button" style="color: rgb(210, 210, 210); display: flex; opacity: 1;"/>
+            <ui:Button text="研究" name="SkillTree" class="button" style="height: 100px; width: 200px; -unity-text-align: middle-center; font-size: 36px; -unity-font-style: bold; background-color: rgba(255, 255, 255, 0); color: rgb(209, 209, 209); display: flex; opacity: 1;"/>
+            <ui:Button text="改造" name="SkillSelect" class="button" style="height: 100px; width: 200px; -unity-text-align: middle-center; font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); color: rgb(210, 210, 210); display: flex; opacity: 1;"/>
+            <ui:Button text="設定" name="Setting" class="button" style="height: 100px; width: 200px; -unity-text-align: middle-center; font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); color: rgb(210, 210, 210); display: flex; opacity: 1;"/>
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Home.uxml.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Home.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d6056ed1cde932548a8de79a607b99c6
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/OutGame.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/OutGame.uxml
@@ -8,5 +8,5 @@
     <ui:Instance template="StageSelect" name="StageSelectContainer" style="position: absolute; width: 100%; height: 100%; display: none;"/>
     <ui:Instance template="SkillTree" name="SkillTreeContainer" style="position: absolute; width: 100%; height: 100%; display: none;"/>
     <ui:Instance template="SkillConfiguration" name="SkillBuildContainer" style="position: absolute; width: 100%; height: 100%; display: none;"/>
-    <ui:Instance template="Setting" name="SettingContainer" style="display: none;"/>
+    <ui:Instance template="Setting" name="SettingContainer" style="position: absolute; width: 100%; height: 100%; display: none;"/>
 </ui:UXML>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/OutGame.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/OutGame.uxml
@@ -1,0 +1,12 @@
+<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <ui:Template name="Home" src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Home.uxml?fileID=9197481963319205126&amp;guid=d6056ed1cde932548a8de79a607b99c6&amp;type=3#Home"/>
+    <ui:Template name="Setting" src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Setting.uxml?fileID=9197481963319205126&amp;guid=c0bfd75645ca6fd4e95372f8837c05d5&amp;type=3#Setting"/>
+    <ui:Template name="SkillConfiguration" src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/SkillBuild.uxml?fileID=9197481963319205126&amp;guid=d25d21c4589e34248aa3ead41ca37903&amp;type=3#SkillBuild"/>
+    <ui:Template name="SkillTree" src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/SkillTree.uxml?fileID=9197481963319205126&amp;guid=71fa5cfbe14c0f24a9c468147eb5fef7&amp;type=3#SkillTree"/>
+    <ui:Template name="StageSelect" src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/StageSelect.uxml?fileID=9197481963319205126&amp;guid=6114da1f8d46b1a48ab03c626ed1d9e9&amp;type=3#StageSelect"/>
+    <ui:Instance template="Home" name="HomeContainer" style="height: 100%; width: 100%; position: absolute;"/>
+    <ui:Instance template="StageSelect" name="StageSelectContainer" style="position: absolute; width: 100%; height: 100%; display: none;"/>
+    <ui:Instance template="SkillTree" name="SkillTreeContainer" style="position: absolute; width: 100%; height: 100%; display: none;"/>
+    <ui:Instance template="SkillConfiguration" name="SkillBuildContainer" style="position: absolute; width: 100%; height: 100%; display: none;"/>
+    <ui:Instance template="Setting" name="SettingContainer" style="display: none;"/>
+</ui:UXML>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/OutGame.uxml.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/OutGame.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: e59e88499d314f84aac92e44c089c1c4
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Setting.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Setting.uxml
@@ -1,0 +1,10 @@
+<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <ui:VisualElement picking-mode="Position" style="flex-grow: 1; width: 100%; height: 100%; justify-content: center; align-items: center; align-content: center; position: absolute; transition-duration: 0.5s; transition-timing-function: ease-in-cubic; background-color: rgba(0, 0, 0, 0.15); display: flex; opacity: 1;">
+        <ui:VisualElement style="flex-grow: 0; width: 800px; height: 500px; justify-content: flex-start; align-items: flex-start; align-content: auto; background-color: rgba(94, 87, 87, 0.78);">
+            <ui:Label text="設定" name="HeadLine" style="white-space: pre; align-items: auto; font-size: 36px; -unity-font-style: bold; align-content: auto; margin-left: 10px; justify-content: flex-start;"/>
+            <ui:Button text="戻る" name="BackButton" class="button" style="width: 100px; height: 50px; align-self: flex-end; justify-content: flex-start; align-items: auto; align-content: flex-end; color: rgb(255, 255, 255); font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); margin-right: 30px; -unity-text-align: middle-left; position: relative; top: 360px; left: 0;"/>
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Setting.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Setting.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
     <ui:VisualElement picking-mode="Position" style="flex-grow: 1; width: 100%; height: 100%; justify-content: center; align-items: center; align-content: center; position: absolute; transition-duration: 0.5s; transition-timing-function: ease-in-cubic; background-color: rgba(0, 0, 0, 0.15); display: flex; opacity: 1;">
         <ui:VisualElement style="flex-grow: 0; width: 800px; height: 500px; justify-content: flex-start; align-items: flex-start; align-content: auto; background-color: rgba(94, 87, 87, 0.78);">
             <ui:Label text="設定" name="HeadLine" style="white-space: pre; align-items: auto; font-size: 36px; -unity-font-style: bold; align-content: auto; margin-left: 10px; justify-content: flex-start;"/>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Setting.uxml.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Setting.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: c0bfd75645ca6fd4e95372f8837c05d5
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillBuild.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillBuild.uxml
@@ -1,0 +1,8 @@
+<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <ui:VisualElement style="flex-grow: 1; background-color: rgb(218, 165, 32);">
+        <ui:Label text="改造" name="HeadLine" enable-rich-text="true" style="width: 200px; height: 100px; -unity-text-align: middle-center; -unity-font-style: bold; font-size: 36px;"/>
+        <ui:Button text="戻る" name="BackButton" class="button" style="width: 200px; height: 100px; align-self: flex-end; justify-content: flex-start; align-items: flex-end; align-content: auto; color: rgb(255, 255, 255); font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); margin-right: 30px;"/>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillBuild.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillBuild.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
     <ui:VisualElement style="flex-grow: 1; background-color: rgb(218, 165, 32);">
         <ui:Label text="改造" name="HeadLine" enable-rich-text="true" style="width: 200px; height: 100px; -unity-text-align: middle-center; -unity-font-style: bold; font-size: 36px;"/>
         <ui:Button text="戻る" name="BackButton" class="button" style="width: 200px; height: 100px; align-self: flex-end; justify-content: flex-start; align-items: flex-end; align-content: auto; color: rgb(255, 255, 255); font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); margin-right: 30px;"/>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillBuild.uxml.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillBuild.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d25d21c4589e34248aa3ead41ca37903
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillTree.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillTree.uxml
@@ -1,0 +1,8 @@
+<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <ui:VisualElement style="flex-grow: 1; background-color: rgb(55, 164, 164);">
+        <ui:Label text="研究" name="HeadLine" selectable="true" focusable="true" style="font-size: 36px; -unity-font-style: bold; width: 200px; height: 100px; -unity-text-align: middle-center;"/>
+        <ui:Button text="戻る" name="BackButton" class="button" style="width: 200px; height: 100px; align-self: flex-end; justify-content: flex-start; align-items: flex-end; align-content: auto; color: rgb(255, 255, 255); font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); margin-right: 30px;"/>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillTree.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillTree.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
     <ui:VisualElement style="flex-grow: 1; background-color: rgb(55, 164, 164);">
         <ui:Label text="研究" name="HeadLine" selectable="true" focusable="true" style="font-size: 36px; -unity-font-style: bold; width: 200px; height: 100px; -unity-text-align: middle-center;"/>
         <ui:Button text="戻る" name="BackButton" class="button" style="width: 200px; height: 100px; align-self: flex-end; justify-content: flex-start; align-items: flex-end; align-content: auto; color: rgb(255, 255, 255); font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); margin-right: 30px;"/>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillTree.uxml.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/SkillTree.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 71fa5cfbe14c0f24a9c468147eb5fef7
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/StageSelect.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/StageSelect.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
-    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <Style src="project://database/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
     <ui:VisualElement name="VisualElement" style="flex-grow: 1; width: 100%; height: 100%; background-color: rgb(106, 59, 37);">
         <ui:Label text="作戦" name="HeadLine" style="height: 100px; width: 200px; display: flex; visibility: visible; opacity: 1; -unity-font-style: bold; font-size: 36px; -unity-text-align: middle-center;"/>
         <ui:Button text="戻る" name="BackButton" class="button" style="width: 200px; height: 100px; align-self: flex-end; justify-content: flex-start; align-items: flex-end; align-content: auto; color: rgb(255, 255, 255); font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); margin-right: 30px;"/>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/StageSelect.uxml
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/StageSelect.uxml
@@ -1,0 +1,8 @@
+<ui:UXML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/OutGameScreen.uss?fileID=7433441132597879392&amp;guid=2873ded5d140af5419fca59e2bf1d22c&amp;type=3#OutGameScreen"/>
+    <Style src="project://database/Assets/UI%20Toolkit/Uss/Button.uss?fileID=7433441132597879392&amp;guid=1e78d0c0c6f33384896221d772a80442&amp;type=3#Button"/>
+    <ui:VisualElement name="VisualElement" style="flex-grow: 1; width: 100%; height: 100%; background-color: rgb(106, 59, 37);">
+        <ui:Label text="作戦" name="HeadLine" style="height: 100px; width: 200px; display: flex; visibility: visible; opacity: 1; -unity-font-style: bold; font-size: 36px; -unity-text-align: middle-center;"/>
+        <ui:Button text="戻る" name="BackButton" class="button" style="width: 200px; height: 100px; align-self: flex-end; justify-content: flex-start; align-items: flex-end; align-content: auto; color: rgb(255, 255, 255); font-size: 36px; -unity-font-style: bold; background-color: rgba(188, 188, 188, 0); margin-right: 30px;"/>
+    </ui:VisualElement>
+</ui:UXML>

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/StageSelect.uxml.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/StageSelect.uxml.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6114da1f8d46b1a48ab03c626ed1d9e9
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0fe38ceaeb2bbed4792bcae5b6fb97d8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss/Button.uss
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss/Button.uss
@@ -1,0 +1,20 @@
+:root {
+}
+
+.button {
+    height: 100px;
+    width: 200px;
+    -unity-text-align: middle-center;
+    font-size: 36px;
+    -unity-font-style: bold;
+    margin-top: 10px;
+    background-color: rgba(188, 188, 188, 0);
+}
+
+.button:hover {
+    scale: 1.2 1.2 1.2;
+    transition-duration: 0.2s;
+    transition-timing-function: ease-out-circ;
+}
+
+

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss/Button.uss.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss/Button.uss.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1e78d0c0c6f33384896221d772a80442
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0
+  unsupportedSelectorAction: 0

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss/OutGameScreen.uss
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss/OutGameScreen.uss
@@ -1,0 +1,20 @@
+:root {
+}
+
+.screen-hidden {
+    position: absolute;
+    opacity: 0;
+    display: none;
+}
+
+.screen-visible {
+    flex-grow: 1;
+    background-color: rgb(53, 65, 72);
+    width: 100%;
+    height: 100%;
+    transition-duration: 0.5s;
+    transition-timing-function: ease-in-out;
+    position: absolute;
+    opacity: 1;
+    display: flex;
+}

--- a/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss/OutGameScreen.uss.meta
+++ b/Assets/Level/Scenes/Develop/OutGameTest/ScreenTransitionTest/UI Toolkit/Uss/OutGameScreen.uss.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2873ded5d140af5419fca59e2bf1d22c
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0
+  unsupportedSelectorAction: 0

--- a/Assets/Scripts/Runtime/1.Domain/OutGame/Screen.meta
+++ b/Assets/Scripts/Runtime/1.Domain/OutGame/Screen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 40e149f2b4deb5643bdddc53aee52708
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenId.cs
+++ b/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenId.cs
@@ -5,8 +5,6 @@ namespace KillChord.Runtime.Domain.OutGame.Screen
     /// </summary>
     public enum ScreenId
     {
-        /// <summary> 定義なし。 </summary>
-        None,
         /// <summary> ホーム画面。 </summary>
         Home,
         /// <summary> 作戦画面。 </summary>

--- a/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenId.cs
+++ b/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenId.cs
@@ -1,0 +1,21 @@
+namespace KillChord.Runtime.Domain.OutGame.Screen
+{
+    /// <summary>
+    ///     アウトゲームの画面を表す列挙型。
+    /// </summary>
+    public enum ScreenId
+    {
+        /// <summary> 定義なし。 </summary>
+        None,
+        /// <summary> ホーム画面。 </summary>
+        Home,
+        /// <summary> 作戦画面。 </summary>
+        StageSelect,
+        /// <summary> 研究画面。 </summary>
+        SkillTree,
+        /// <summary> 改造画面。 </summary>
+        SkillBuild,
+        /// <summary> 設定画面。 </summary>
+        Setting,
+    }
+}

--- a/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenId.cs.meta
+++ b/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenId.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36f0e215b19a69641b0ff0394366a6d0

--- a/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenTransitionRule.cs
+++ b/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenTransitionRule.cs
@@ -1,0 +1,23 @@
+namespace KillChord.Runtime.Domain.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移のルールを表す値オブジェクト。
+    /// </summary>
+    public readonly struct ScreenTransitionRule
+    {
+        /// <summary>
+        ///     遷移ルールを初期化します。
+        /// </summary>
+        public ScreenTransitionRule(ScreenTransitionType transitionType, bool keepInHistory)
+        {
+            TransitionType = transitionType;
+            KeepInHistory = keepInHistory;
+        }
+
+        /// <summary> 遷移の種類を取得します。 </summary>
+        public ScreenTransitionType TransitionType { get; }
+
+        /// <summary> 履歴へ積むかどうかを取得します。 </summary>
+        public bool KeepInHistory { get; }
+    }
+}

--- a/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenTransitionRule.cs.meta
+++ b/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenTransitionRule.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c75a8dc2661c76a44b221924c8dbfefa

--- a/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenTransitionType.cs
+++ b/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenTransitionType.cs
@@ -1,0 +1,15 @@
+namespace KillChord.Runtime.Domain.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移の種類を表す列挙型。
+    /// </summary>
+    public enum ScreenTransitionType
+    {
+        /// <summary> 前の画面を隠す。 </summary>
+        Replace,
+        /// <summary> 前の画面に重ねる。 </summary>
+        Overlay,
+        /// <summary> 画面遷移後履歴を消す。 </summary>
+        Reset,
+    }
+}

--- a/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenTransitionType.cs.meta
+++ b/Assets/Scripts/Runtime/1.Domain/OutGame/Screen/ScreenTransitionType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 30844f693e091cc4eba8e0b1534b4e5a

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d0c51611a72e19847b731cea23064d68
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/CloseCurrentScreenUseCase.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/CloseCurrentScreenUseCase.cs
@@ -1,4 +1,6 @@
 using KillChord.Runtime.Domain.OutGame.Screen;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace KillChord.Runtime.Application.OutGame.Screen
 {
@@ -21,7 +23,7 @@ namespace KillChord.Runtime.Application.OutGame.Screen
         /// <summary>
         ///     現在開いている画面を閉じます。
         /// </summary>
-        public void Execute()
+        public async Task Execute(CancellationToken token)
         {
             ScreenTransitionState transitionState = _screenStateRepository.TransitionState;
             ScreenId? currentScreenId = transitionState.CurrentScreenId;
@@ -41,7 +43,7 @@ namespace KillChord.Runtime.Application.OutGame.Screen
                 previousScreenId,
                 clearHistory: false);
 
-            _screenPresenter.Present(result);
+            await _screenPresenter.Present(result, token);
         }
 
         private readonly IScreenPresenter _screenPresenter;

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/CloseCurrentScreenUseCase.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/CloseCurrentScreenUseCase.cs
@@ -1,0 +1,50 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Application.OutGame.Screen
+{
+    /// <summary>
+    ///     現在開いている画面を閉じるユースケース。
+    /// </summary>
+    public sealed class CloseCurrentScreenUseCase
+    {
+        /// <summary>
+        ///     ユースケースを初期化します。
+        /// </summary>
+        public CloseCurrentScreenUseCase(
+            IScreenStateRepository screenStateRepository,
+            IScreenPresenter screenPresenter)
+        {
+            _screenStateRepository = screenStateRepository;
+            _screenPresenter = screenPresenter;
+        }
+
+        /// <summary>
+        ///     現在開いている画面を閉じます。
+        /// </summary>
+        public void Execute()
+        {
+            ScreenTransitionState transitionState = _screenStateRepository.TransitionState;
+            ScreenId? currentScreenId = transitionState.CurrentScreenId;
+
+            if (currentScreenId.HasValue == false)
+            {
+                return;
+            }
+
+            if (!transitionState.TryGoBack(out ScreenId previousScreenId))
+            {
+                return;
+            }
+
+            ScreenTransitionResult result = new(
+                currentScreenId,
+                previousScreenId,
+                clearHistory: false);
+
+            _screenPresenter.Present(result);
+        }
+
+        private readonly IScreenPresenter _screenPresenter;
+        private readonly IScreenStateRepository _screenStateRepository;
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/CloseCurrentScreenUseCase.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/CloseCurrentScreenUseCase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c63b244401bd5e4d8329256ad954714

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenPresenter.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenPresenter.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace KillChord.Runtime.Application.OutGame.Screen
 {
     /// <summary>
@@ -8,6 +11,6 @@ namespace KillChord.Runtime.Application.OutGame.Screen
         /// <summary>
         ///     画面遷移結果を出力します。
         /// </summary>
-        void Present(ScreenTransitionResult result);
+        Task Present(ScreenTransitionResult result, CancellationToken token);
     }
 }

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenPresenter.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenPresenter.cs
@@ -1,0 +1,13 @@
+namespace KillChord.Runtime.Application.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移結果の出力先インターフェース。
+    /// </summary>
+    public interface IScreenPresenter
+    {
+        /// <summary>
+        ///     画面遷移結果を出力します。
+        /// </summary>
+        void Present(ScreenTransitionResult result);
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenPresenter.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenPresenter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0c718298a8aab14f9af2c2e84e7307d

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenRuleRepository.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenRuleRepository.cs
@@ -1,0 +1,15 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Application.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移ルール取得のインターフェース。
+    /// </summary>
+    public interface IScreenRuleRepository
+    {
+        /// <summary>
+        ///     指定画面の遷移ルールを取得します。
+        /// </summary>
+        ScreenTransitionRule GetRule(ScreenId screenId);
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenRuleRepository.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenRuleRepository.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69fd2761b03e7f2498be46d510f2de70

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenStateRepository.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenStateRepository.cs
@@ -1,0 +1,11 @@
+namespace KillChord.Runtime.Application.OutGame.Screen
+{
+    /// <summary>
+    ///     画面状態リポジトリのインターフェース。
+    /// </summary>
+    public interface IScreenStateRepository
+    {
+        /// <summary> 画面遷移状態を取得します。 </summary>
+        ScreenTransitionState TransitionState { get; }
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenStateRepository.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/IScreenStateRepository.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63ff5cbbb64199c469b9a9a54452f391

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ResetToHomeScreenUseCase.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ResetToHomeScreenUseCase.cs
@@ -1,0 +1,42 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Application.OutGame.Screen
+{
+    /// <summary>
+    ///     ホーム画面へ復帰するユースケース。
+    /// </summary>
+    public sealed class ResetToHomeScreenUseCase
+    {
+        /// <summary>
+        ///     ユースケースを初期化します。
+        /// </summary>
+        public ResetToHomeScreenUseCase(
+            IScreenStateRepository screenStateRepository,
+            IScreenPresenter screenPresenter)
+        {
+            _screenStateRepository = screenStateRepository;
+            _screenPresenter = screenPresenter;
+        }
+
+        /// <summary>
+        ///     ホーム画面へ復帰します。
+        /// </summary>
+        public void Execute()
+        {
+            ScreenTransitionState transitionState = _screenStateRepository.TransitionState;
+            ScreenId? previousScreenId = transitionState.CurrentScreenId;
+
+            transitionState.Reset(ScreenId.Home);
+
+            ScreenTransitionResult result = new(
+                previousScreenId,
+                ScreenId.Home,
+                clearHistory: true);
+
+            _screenPresenter.Present(result);
+        }
+
+        private readonly IScreenPresenter _screenPresenter;
+        private readonly IScreenStateRepository _screenStateRepository;
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ResetToHomeScreenUseCase.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ResetToHomeScreenUseCase.cs
@@ -1,4 +1,6 @@
 using KillChord.Runtime.Domain.OutGame.Screen;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace KillChord.Runtime.Application.OutGame.Screen
 {
@@ -21,7 +23,7 @@ namespace KillChord.Runtime.Application.OutGame.Screen
         /// <summary>
         ///     ホーム画面へ復帰します。
         /// </summary>
-        public void Execute()
+        public async Task Execute(CancellationToken token)
         {
             ScreenTransitionState transitionState = _screenStateRepository.TransitionState;
             ScreenId? previousScreenId = transitionState.CurrentScreenId;
@@ -33,7 +35,7 @@ namespace KillChord.Runtime.Application.OutGame.Screen
                 ScreenId.Home,
                 clearHistory: true);
 
-            _screenPresenter.Present(result);
+            await _screenPresenter.Present(result, token);
         }
 
         private readonly IScreenPresenter _screenPresenter;

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ResetToHomeScreenUseCase.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ResetToHomeScreenUseCase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d439f866b007eae418fc3da9916178b3

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ScreenTransitionResult.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ScreenTransitionResult.cs
@@ -1,0 +1,32 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Application.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移結果を表します。
+    /// </summary>
+    public readonly struct ScreenTransitionResult
+    {
+        /// <summary>
+        ///     画面遷移結果を初期化します。
+        /// </summary>
+        public ScreenTransitionResult(
+            ScreenId? screenToHideId,
+            ScreenId screenToShowId,
+            bool clearHistory)
+        {
+            ScreenToHideId = screenToHideId;
+            ScreenToShowId = screenToShowId;
+            ClearHistory = clearHistory;
+        }
+
+        /// <summary> 非表示対象画面 ID を取得します。 </summary>
+        public ScreenId? ScreenToHideId { get; }
+
+        /// <summary> 表示対象画面 ID を取得します。 </summary>
+        public ScreenId ScreenToShowId { get; }
+
+        /// <summary> 履歴クリアを伴うかどうかを取得します。 </summary>
+        public bool ClearHistory { get; }
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ScreenTransitionResult.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ScreenTransitionResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aec567fc1b3ced247be003698c622566

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ScreenTransitionState.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ScreenTransitionState.cs
@@ -1,0 +1,54 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+using System.Collections.Generic;
+
+namespace KillChord.Runtime.Application.OutGame.Screen      
+{
+    /// <summary>
+    ///     画面遷移状態を保持するクラス。
+    /// </summary>
+    public sealed class ScreenTransitionState
+    {
+        /// <summary> 現在画面 ID を取得します。 </summary>
+        public ScreenId? CurrentScreenId { get; private set; }
+
+        /// <summary>
+        ///     指定画面へ遷移します。
+        /// </summary>
+        public void MoveTo(ScreenId nextScreenId, bool keepInHistory)
+        {
+            if (keepInHistory && CurrentScreenId.HasValue)
+            {
+                _history.Push(CurrentScreenId.Value);
+            }
+
+            CurrentScreenId = nextScreenId;
+        }
+
+        /// <summary>
+        ///     戻り先画面の取得を試みます。
+        /// </summary>
+        public bool TryGoBack(out ScreenId previousScreenId)
+        {
+            if (_history.Count == 0)
+            {
+                previousScreenId = default;
+                return false;
+            }
+
+            previousScreenId = _history.Pop();
+            CurrentScreenId = previousScreenId;
+            return true;
+        }
+
+        /// <summary>
+        ///     履歴をクリアし、ルート画面へ戻します。
+        /// </summary>
+        public void Reset(ScreenId rootScreenId)
+        {
+            _history.Clear();
+            CurrentScreenId = rootScreenId;
+        }
+
+        private readonly Stack<ScreenId> _history = new();
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ScreenTransitionState.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ScreenTransitionState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: db77d08655bbbef4faf1467c4d667ada

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenCommand.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenCommand.cs
@@ -1,0 +1,21 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Application.OutGame.Screen
+{
+    /// <summary>
+    ///     画面表示コマンド。
+    /// </summary>
+    public readonly struct ShowScreenCommand
+    {
+        /// <summary> 
+        ///     画面表示コマンドを初期化します。
+        /// </summary>
+        public ShowScreenCommand(ScreenId targetScreenId)
+        {
+            TargetScreenId = targetScreenId;
+        }
+
+        /// <summary> 遷移先画面 ID を取得します。 </summary>
+        public ScreenId TargetScreenId { get; }
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenCommand.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenCommand.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f34990852ccb08345862ccf90eb3ebf0

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenUseCase.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenUseCase.cs
@@ -1,4 +1,6 @@
 using KillChord.Runtime.Domain.OutGame.Screen;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace KillChord.Runtime.Application.OutGame.Screen
 {
@@ -23,7 +25,7 @@ namespace KillChord.Runtime.Application.OutGame.Screen
         /// <summary>
         ///     指定された画面を表示します。
         /// </summary>
-        public void Execute(ShowScreenCommand command)
+        public async Task Execute(ShowScreenCommand command, CancellationToken token)
         {
             ScreenTransitionState transitionState = _screenStateRepository.TransitionState;
             ScreenId? previousScreenId = transitionState.CurrentScreenId;
@@ -46,7 +48,7 @@ namespace KillChord.Runtime.Application.OutGame.Screen
                 command.TargetScreenId,
                 rule.TransitionType == ScreenTransitionType.Reset);
 
-            _screenPresenter.Present(result);
+            await _screenPresenter.Present(result, token);
         }
 
         private readonly IScreenPresenter _screenPresenter;

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenUseCase.cs
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenUseCase.cs
@@ -1,0 +1,56 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Application.OutGame.Screen
+{
+    /// <summary>
+    ///     指定された画面を表示するユースケース。
+    /// </summary>
+    public sealed class ShowScreenUseCase
+    {
+        /// <summary>
+        ///     ユースケースを初期化します。
+        /// </summary>
+        public ShowScreenUseCase(
+            IScreenStateRepository screenStateRepository,
+            IScreenRuleRepository screenRuleRepository,
+            IScreenPresenter screenPresenter)
+        {
+            _screenStateRepository = screenStateRepository;
+            _screenRuleRepository = screenRuleRepository;
+            _screenPresenter = screenPresenter;
+        }
+
+        /// <summary>
+        ///     指定された画面を表示します。
+        /// </summary>
+        public void Execute(ShowScreenCommand command)
+        {
+            ScreenTransitionState transitionState = _screenStateRepository.TransitionState;
+            ScreenId? previousScreenId = transitionState.CurrentScreenId;
+            ScreenTransitionRule rule = _screenRuleRepository.GetRule(command.TargetScreenId);
+
+            if (rule.TransitionType == ScreenTransitionType.Reset)
+            {
+                transitionState.Reset(command.TargetScreenId);
+            }
+            else
+            {
+                transitionState.MoveTo(command.TargetScreenId, rule.KeepInHistory);
+            }
+
+            bool hidePreviousScreen = rule.TransitionType == ScreenTransitionType.Replace ||
+                rule.TransitionType == ScreenTransitionType.Reset;
+
+            ScreenTransitionResult result = new(
+                hidePreviousScreen ? previousScreenId : null,
+                command.TargetScreenId,
+                rule.TransitionType == ScreenTransitionType.Reset);
+
+            _screenPresenter.Present(result);
+        }
+
+        private readonly IScreenPresenter _screenPresenter;
+        private readonly IScreenRuleRepository _screenRuleRepository;
+        private readonly IScreenStateRepository _screenStateRepository;
+    }
+}

--- a/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenUseCase.cs.meta
+++ b/Assets/Scripts/Runtime/2.Application/OutGame/Screen/ShowScreenUseCase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b4c57f5f0d9b614fb19bc5ae5777b36

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen.meta
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d87dc635f544d2a4f80f552c9fda1094
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenController.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenController.cs
@@ -1,0 +1,26 @@
+namespace KillChord.Runtime.Adaptor.OutGame.Screen
+{
+    /// <summary>
+    ///     画面操作をユースケースへ伝達するためのインターフェース。
+    /// </summary>
+    public interface IScreenController
+    {
+        /// <summary> ホーム画面を表示します。 </summary>
+        void ShowHome();
+
+        /// <summary> ステージ選択画面を表示します。 </summary>
+        void ShowStageSelect();
+
+        /// <summary> スキルツリー画面を表示します。 </summary>
+        void ShowSkillTree();
+
+        /// <summary> スキル選択画面を表示します。 </summary>
+        void ShowSkillBuild();
+
+        /// <summary> 設定画面を表示します。 </summary>
+        void ShowSetting();
+
+        /// <summary> 現在画面を閉じます。 </summary>
+        void CloseCurrent();
+    }
+}

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenController.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenController.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace KillChord.Runtime.Adaptor.OutGame.Screen
 {
     /// <summary>
@@ -6,21 +9,21 @@ namespace KillChord.Runtime.Adaptor.OutGame.Screen
     public interface IScreenController
     {
         /// <summary> ホーム画面を表示します。 </summary>
-        void ShowHome();
+        Task ShowHome(CancellationToken token);
 
         /// <summary> ステージ選択画面を表示します。 </summary>
-        void ShowStageSelect();
+        Task ShowStageSelect(CancellationToken token);
 
         /// <summary> スキルツリー画面を表示します。 </summary>
-        void ShowSkillTree();
+        Task ShowSkillTree(CancellationToken token);
 
         /// <summary> スキル選択画面を表示します。 </summary>
-        void ShowSkillBuild();
+        Task ShowSkillBuild(CancellationToken token);
 
         /// <summary> 設定画面を表示します。 </summary>
-        void ShowSetting();
+        Task ShowSetting(CancellationToken token);
 
         /// <summary> 現在画面を閉じます。 </summary>
-        void CloseCurrent();
+        Task CloseCurrent(CancellationToken token);
     }
 }

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenController.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenController.cs
@@ -11,13 +11,13 @@ namespace KillChord.Runtime.Adaptor.OutGame.Screen
         /// <summary> ホーム画面を表示します。 </summary>
         Task ShowHome(CancellationToken token);
 
-        /// <summary> ステージ選択画面を表示します。 </summary>
+        /// <summary> 作戦画面を表示します。 </summary>
         Task ShowStageSelect(CancellationToken token);
 
-        /// <summary> スキルツリー画面を表示します。 </summary>
+        /// <summary> 研究画面を表示します。 </summary>
         Task ShowSkillTree(CancellationToken token);
 
-        /// <summary> スキル選択画面を表示します。 </summary>
+        /// <summary> 改造画面を表示します。 </summary>
         Task ShowSkillBuild(CancellationToken token);
 
         /// <summary> 設定画面を表示します。 </summary>

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenController.cs.meta
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 790260846d975564fab7d13eb6d67406

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenTransitionApplicable.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenTransitionApplicable.cs
@@ -1,0 +1,13 @@
+namespace KillChord.Runtime.Adaptor.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移結果の適用先のインターフェース。
+    /// </summary>
+    public interface IScreenTransitionApplicable
+    {
+        /// <summary>
+        ///     画面遷移結果を適用します。
+        /// </summary>
+        void Apply(in ScreenViewDTO screenViewDTO);
+    }
+}

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenTransitionApplicable.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenTransitionApplicable.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace KillChord.Runtime.Adaptor.OutGame.Screen
 {
     /// <summary>
@@ -8,6 +11,6 @@ namespace KillChord.Runtime.Adaptor.OutGame.Screen
         /// <summary>
         ///     画面遷移結果を適用します。
         /// </summary>
-        void Apply(in ScreenViewDTO screenViewDTO);
+        Task Apply(in ScreenViewDTO screenViewDTO, CancellationToken token);
     }
 }

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenTransitionApplicable.cs.meta
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenTransitionApplicable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 50ba9784787d1904fb50bb44d9c44088

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenViewRegistry.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenViewRegistry.cs
@@ -1,4 +1,6 @@
 using KillChord.Runtime.Domain.OutGame.Screen;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace KillChord.Runtime.Adaptor.OutGame.Screen
 {
@@ -10,12 +12,12 @@ namespace KillChord.Runtime.Adaptor.OutGame.Screen
         /// <summary>
         ///     指定された画面を表示します。
         /// </summary>
-        void Show(ScreenId screenId);
+        Task Show(ScreenId screenId, CancellationToken token);
 
         /// <summary>
         ///     指定された画面を非表示にします。
         /// </summary>
-        void Hide(ScreenId screenId);
+        Task Hide(ScreenId screenId, CancellationToken token);
 
         /// <summary>
         ///     すべての画面を即座に非表示にします。

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenViewRegistry.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenViewRegistry.cs
@@ -1,0 +1,25 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Adaptor.OutGame.Screen
+{
+    /// <summary>
+    ///     画面表示切り替えのインターフェース。
+    /// </summary>
+    public interface IScreenViewRegistry
+    {
+        /// <summary>
+        ///     指定された画面を表示します。
+        /// </summary>
+        void Show(ScreenId screenId);
+
+        /// <summary>
+        ///     指定された画面を非表示にします。
+        /// </summary>
+        void Hide(ScreenId screenId);
+
+        /// <summary>
+        ///     すべての画面を即座に非表示にします。
+        /// </summary>
+        void HideAllImmediately();
+    }
+}

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenViewRegistry.cs.meta
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/IScreenViewRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f2e149121c3542a4a8acac35f6e4f908

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenController.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenController.cs
@@ -1,0 +1,76 @@
+using KillChord.Runtime.Application.OutGame.Screen;
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Adaptor.OutGame.Screen
+{
+    /// <summary>
+    ///     画面操作をユースケースへ伝達する Controller。
+    /// </summary>
+    public sealed class ScreenController : IScreenController
+    {
+        /// <summary>
+        ///     Controller を初期化します。
+        /// </summary>
+        public ScreenController(
+            ShowScreenUseCase showScreenUseCase,
+            CloseCurrentScreenUseCase closeCurrentScreenUseCase,
+            ResetToHomeScreenUseCase resetToHomeScreenUseCase)
+        {
+            _showScreenUseCase = showScreenUseCase;
+            _closeCurrentScreenUseCase = closeCurrentScreenUseCase;
+            _resetToHomeScreenUseCase = resetToHomeScreenUseCase;
+        }
+
+        /// <summary>
+        ///     ホーム画面を表示します。
+        /// </summary>
+        public void ShowHome()
+        {
+            _resetToHomeScreenUseCase.Execute();
+        }
+
+        /// <summary>
+        ///     作戦画面を表示します。
+        /// </summary>
+        public void ShowStageSelect()
+        {
+            _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.StageSelect));
+        }
+
+        /// <summary>
+        ///     研究画面を表示します。
+        /// </summary>
+        public void ShowSkillTree()
+        {
+            _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.SkillTree));
+        }
+
+        /// <summary>
+        ///     改造画面を表示します。
+        /// </summary>
+        public void ShowSkillBuild()
+        {
+            _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.SkillBuild));
+        }
+
+        /// <summary>
+        ///     設定画面を表示します。
+        /// </summary>
+        public void ShowSetting()
+        {
+            _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.Setting));
+        }
+
+        /// <summary>
+        ///     現在画面を閉じます。
+        /// </summary>
+        public void CloseCurrent()
+        {
+            _closeCurrentScreenUseCase.Execute();
+        }
+
+        private readonly CloseCurrentScreenUseCase _closeCurrentScreenUseCase;
+        private readonly ResetToHomeScreenUseCase _resetToHomeScreenUseCase;
+        private readonly ShowScreenUseCase _showScreenUseCase;
+    }
+}

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenController.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenController.cs
@@ -1,5 +1,7 @@
 using KillChord.Runtime.Application.OutGame.Screen;
 using KillChord.Runtime.Domain.OutGame.Screen;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace KillChord.Runtime.Adaptor.OutGame.Screen
 {
@@ -24,49 +26,49 @@ namespace KillChord.Runtime.Adaptor.OutGame.Screen
         /// <summary>
         ///     ホーム画面を表示します。
         /// </summary>
-        public void ShowHome()
+        public async Task ShowHome(CancellationToken token)
         {
-            _resetToHomeScreenUseCase.Execute();
+            await _resetToHomeScreenUseCase.Execute(token);
         }
 
         /// <summary>
         ///     作戦画面を表示します。
         /// </summary>
-        public void ShowStageSelect()
+        public async Task ShowStageSelect(CancellationToken token)
         {
-            _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.StageSelect));
+            await _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.StageSelect), token);
         }
 
         /// <summary>
         ///     研究画面を表示します。
         /// </summary>
-        public void ShowSkillTree()
+        public async Task ShowSkillTree(CancellationToken token)
         {
-            _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.SkillTree));
+            await _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.SkillTree), token);
         }
 
         /// <summary>
         ///     改造画面を表示します。
         /// </summary>
-        public void ShowSkillBuild()
+        public async Task ShowSkillBuild(CancellationToken token)
         {
-            _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.SkillBuild));
+            await _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.SkillBuild), token);
         }
 
         /// <summary>
         ///     設定画面を表示します。
         /// </summary>
-        public void ShowSetting()
+        public async Task ShowSetting(CancellationToken token)
         {
-            _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.Setting));
+            await _showScreenUseCase.Execute(new ShowScreenCommand(ScreenId.Setting), token);
         }
 
         /// <summary>
         ///     現在画面を閉じます。
         /// </summary>
-        public void CloseCurrent()
+        public async Task CloseCurrent(CancellationToken token)
         {
-            _closeCurrentScreenUseCase.Execute();
+            await _closeCurrentScreenUseCase.Execute(token);
         }
 
         private readonly CloseCurrentScreenUseCase _closeCurrentScreenUseCase;

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenController.cs.meta
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2851f6341798afc46933485d7ef6d8eb

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenPresenter.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenPresenter.cs
@@ -1,0 +1,32 @@
+using KillChord.Runtime.Application.OutGame.Screen;
+
+namespace KillChord.Runtime.Adaptor.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移結果を ViewModel へ橋渡しする Presenter。
+    /// </summary>
+    public sealed class ScreenPresenter : IScreenPresenter
+    {
+        /// <summary>
+        ///     Presenter を初期化します。
+        /// </summary>
+        public ScreenPresenter(IScreenTransitionApplicable screenViewModel)
+        {
+            _screenViewModel = screenViewModel;
+        }
+
+        /// <summary>
+        ///     画面遷移結果を出力します。
+        /// </summary>
+        public void Present(ScreenTransitionResult result)
+        {
+            ScreenViewDTO screenViewDTO = new(
+                result.ScreenToHideId,
+                result.ScreenToShowId);
+
+            _screenViewModel.Apply(in screenViewDTO);
+        }
+
+        private readonly IScreenTransitionApplicable _screenViewModel;
+    }
+}

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenPresenter.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenPresenter.cs
@@ -1,4 +1,7 @@
 using KillChord.Runtime.Application.OutGame.Screen;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace KillChord.Runtime.Adaptor.OutGame.Screen
 {
@@ -18,13 +21,13 @@ namespace KillChord.Runtime.Adaptor.OutGame.Screen
         /// <summary>
         ///     画面遷移結果を出力します。
         /// </summary>
-        public void Present(ScreenTransitionResult result)
+        public Task Present(ScreenTransitionResult result, CancellationToken token)
         {
             ScreenViewDTO screenViewDTO = new(
                 result.ScreenToHideId,
                 result.ScreenToShowId);
 
-            _screenViewModel.Apply(in screenViewDTO);
+             return _screenViewModel.Apply(in screenViewDTO, token);
         }
 
         private readonly IScreenTransitionApplicable _screenViewModel;

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenPresenter.cs.meta
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenPresenter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aa8889c106a214d4fb5dd6774d1e8b66

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewApplicator.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewApplicator.cs
@@ -1,3 +1,7 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace KillChord.Runtime.Adaptor.OutGame.Screen
 {
     /// <summary>
@@ -16,14 +20,21 @@ namespace KillChord.Runtime.Adaptor.OutGame.Screen
         /// <summary>
         ///     画面遷移結果を適用します。
         /// </summary>
-        public void Apply(in ScreenViewDTO screenViewDTO)
+        public Task Apply(in ScreenViewDTO screenViewDTO, CancellationToken token)
         {
-            if (screenViewDTO.ScreenToHideId.HasValue)
+            var hideId = screenViewDTO.ScreenToHideId;
+            var showId = screenViewDTO.ScreenToShowId;
+            return ApplyInternalAsync(hideId, showId, token);
+        }
+
+        private async Task ApplyInternalAsync(ScreenId? hideId, ScreenId showId, CancellationToken token)
+        {
+            if (hideId.HasValue)
             {
-                _screenViewRegistry.Hide(screenViewDTO.ScreenToHideId.Value);
+                await _screenViewRegistry.Hide(hideId.Value, token);
             }
 
-            _screenViewRegistry.Show(screenViewDTO.ScreenToShowId);
+            await _screenViewRegistry.Show(showId, token);
         }
 
         private readonly IScreenViewRegistry _screenViewRegistry;

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewApplicator.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewApplicator.cs
@@ -1,0 +1,31 @@
+namespace KillChord.Runtime.Adaptor.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移結果を View へ適用する Applicator。
+    /// </summary>
+    public sealed class ScreenViewApplicator : IScreenTransitionApplicable
+    {
+        /// <summary>
+        ///     Applicator を初期化します。
+        /// </summary>
+        public ScreenViewApplicator(IScreenViewRegistry screenViewRegistry)
+        {
+            _screenViewRegistry = screenViewRegistry;
+        }
+
+        /// <summary>
+        ///     画面遷移結果を適用します。
+        /// </summary>
+        public void Apply(in ScreenViewDTO screenViewDTO)
+        {
+            if (screenViewDTO.ScreenToHideId.HasValue)
+            {
+                _screenViewRegistry.Hide(screenViewDTO.ScreenToHideId.Value);
+            }
+
+            _screenViewRegistry.Show(screenViewDTO.ScreenToShowId);
+        }
+
+        private readonly IScreenViewRegistry _screenViewRegistry;
+    }
+}

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewApplicator.cs.meta
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewApplicator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87cfa0c3c862a7940a572c72fd0d5368

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewDTO.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewDTO.cs
@@ -1,0 +1,25 @@
+using KillChord.Runtime.Domain.OutGame.Screen;
+
+namespace KillChord.Runtime.Adaptor.OutGame.Screen
+{
+    /// <summary>
+    ///     View へ渡す画面遷移 DTO。
+    /// </summary>
+    public readonly struct ScreenViewDTO
+    {
+        /// <summary>
+        ///     DTO を初期化します。
+        /// </summary>
+        public ScreenViewDTO(ScreenId? screenToHideId, ScreenId screenToShowId)
+        {
+            ScreenToHideId = screenToHideId;
+            ScreenToShowId = screenToShowId;
+        }
+
+        /// <summary> 非表示対象画面 ID を取得します。 </summary>
+        public ScreenId? ScreenToHideId { get; }
+
+        /// <summary> 表示対象画面 ID を取得します。 </summary>
+        public ScreenId ScreenToShowId { get; }
+    }
+}

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewDTO.cs
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewDTO.cs
@@ -5,7 +5,7 @@ namespace KillChord.Runtime.Adaptor.OutGame.Screen
     /// <summary>
     ///     View へ渡す画面遷移 DTO。
     /// </summary>
-    public readonly struct ScreenViewDTO
+    public readonly ref struct ScreenViewDTO
     {
         /// <summary>
         ///     DTO を初期化します。

--- a/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewDTO.cs.meta
+++ b/Assets/Scripts/Runtime/3.Adaptor/OutGame/Screen/ScreenViewDTO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee71c2f68d1c8e7458ff9d72bc1181f7

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d912795bed4dec24093218c853dcf0ec
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/HomeScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/HomeScreenView.cs
@@ -14,13 +14,20 @@ namespace KillChord.Runtime.View.OutGame.Screen
             : base(rootElement, outGameUIEvent)
         {
             _stageSelectButton = RootElement.Q<Button>(STAGE_SELECT_BUTTON_NAME)
-                ?? throw new System.ArgumentNullException($"{STAGE_SELECT_BUTTON_NAME} が見つかりません。");
+                ?? throw new System.InvalidOperationException(
+                    $"{STAGE_SELECT_BUTTON_NAME} が見つかりません。");
+
             _skillTreeButton = RootElement.Q<Button>(SKILL_TREE_BUTTON_NAME)
-                ?? throw new System.ArgumentNullException($"{SKILL_TREE_BUTTON_NAME} が見つかりません。");
+                ?? throw new System.InvalidOperationException(
+                    $"{SKILL_TREE_BUTTON_NAME} が見つかりません。");
+
             _skillBuildButton = RootElement.Q<Button>(SKILL_BUILD_BUTTON_NAME)
-                ?? throw new System.ArgumentNullException($"{SKILL_BUILD_BUTTON_NAME} が見つかりません。");
+                ?? throw new System.InvalidOperationException(
+                    $"{SKILL_BUILD_BUTTON_NAME} が見つかりません。");
+
             _settingButton = RootElement.Q<Button>(SETTING_BUTTON_NAME)
-                ?? throw new System.ArgumentNullException($"{SETTING_BUTTON_NAME} が見つかりません。");
+                ?? throw new System.InvalidOperationException(
+                    $"{SETTING_BUTTON_NAME} が見つかりません。");
 
             RegisterButtonCallbacks();
         }
@@ -40,11 +47,8 @@ namespace KillChord.Runtime.View.OutGame.Screen
         private void RegisterButtonCallbacks()
         {
             _stageSelectButton.RegisterCallback<ClickEvent>(OnStageSelectClicked);
-
             _skillTreeButton.RegisterCallback<ClickEvent>(OnSkillTreeClicked);
-
             _skillBuildButton.RegisterCallback<ClickEvent>(OnSkillBuildClicked);
-
             _settingButton.RegisterCallback<ClickEvent>(OnSettingClicked);
         }
 

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/HomeScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/HomeScreenView.cs
@@ -1,0 +1,113 @@
+using UnityEngine.UIElements;
+
+namespace KillChord.Runtime.View.OutGame.Screen
+{
+    /// <summary>
+    ///     ホーム画面 View。
+    /// </summary>
+    public sealed class HomeScreenView : ScreenViewBase
+    {
+        /// <summary>
+        ///     View を初期化します。
+        /// </summary>
+        public HomeScreenView(VisualElement rootElement, OutGameUIEvent outGameUIEvent)
+            : base(rootElement, outGameUIEvent)
+        {
+            _stageSelectButton = RootElement.Q<Button>(STAGE_SELECT_BUTTON_NAME)
+                ?? throw new System.ArgumentNullException($"{STAGE_SELECT_BUTTON_NAME} が見つかりません。");
+            _skillTreeButton = RootElement.Q<Button>(SKILL_TREE_BUTTON_NAME)
+                ?? throw new System.ArgumentNullException($"{SKILL_TREE_BUTTON_NAME} が見つかりません。");
+            _skillBuildButton = RootElement.Q<Button>(SKILL_BUILD_BUTTON_NAME)
+                ?? throw new System.ArgumentNullException($"{SKILL_BUILD_BUTTON_NAME} が見つかりません。");
+            _settingButton = RootElement.Q<Button>(SETTING_BUTTON_NAME)
+                ?? throw new System.ArgumentNullException($"{SETTING_BUTTON_NAME} が見つかりません。");
+
+            RegisterButtonCallbacks();
+        }
+
+        /// <summary>
+        ///     リソースを解放します。
+        /// </summary>
+        public override void Dispose()
+        {
+            base.Dispose();
+            UnregisterButtonCallbacks();
+        }
+
+        /// <summary>
+        ///     各ボタンのコールバックを登録します。
+        /// </summary>
+        private void RegisterButtonCallbacks()
+        {
+            _stageSelectButton.RegisterCallback<ClickEvent>(OnStageSelectClicked);
+
+            _skillTreeButton.RegisterCallback<ClickEvent>(OnSkillTreeClicked);
+
+            _skillBuildButton.RegisterCallback<ClickEvent>(OnSkillBuildClicked);
+
+            _settingButton.RegisterCallback<ClickEvent>(OnSettingClicked);
+        }
+
+        /// <summary>
+        ///     各ボタンのコールバックを登録解除します。
+        /// </summary>
+        private void UnregisterButtonCallbacks()
+        {
+            _stageSelectButton?.UnregisterCallback<ClickEvent>(OnStageSelectClicked);
+            _skillTreeButton?.UnregisterCallback<ClickEvent>(OnSkillTreeClicked);
+            _skillBuildButton?.UnregisterCallback<ClickEvent>(OnSkillBuildClicked);
+            _settingButton?.UnregisterCallback<ClickEvent>(OnSettingClicked);
+        }
+
+        /// <summary>
+        ///     作戦ボタンがクリックリされたときのコールバックです。
+        ///     作戦画面を表示するイベントを発行します。
+        /// </summary>
+        /// <param name="evt"> クリックイベントの情報。 </param>
+        private void OnStageSelectClicked(ClickEvent evt)
+        {
+            OutGameUIEvent.OnShownStageSelectionScreen?.Invoke();
+        }
+
+        /// <summary>
+        ///     研究ボタンがクリックされたときのコールバックです。
+        ///     研究画面を表示するイベントを発行します。
+        /// </summary>
+        /// <param name="evt"> クリックイベントの情報。 </param>
+        private void OnSkillTreeClicked(ClickEvent evt)
+        {
+            OutGameUIEvent.OnShownSkillTreeScreen?.Invoke();
+        }
+
+        /// <summary>
+        ///     改造ボタンがクリックされたときのコールバックです。
+        ///     改造画面を表示するイベントを発行します。
+        /// </summary>
+        /// <param name="evt"> クリックイベントの情報。 </param>
+        private void OnSkillBuildClicked(ClickEvent evt)
+        {
+            OutGameUIEvent.OnShownSkillBuildScreen?.Invoke();
+        }
+
+        /// <summary>
+        ///     設定ボタンがクリックされたときのコールバックです。
+        ///     設定画面を表示するイベントを発行します。
+        /// </summary>
+        /// <param name="evt"> クリックイベントの情報。 </param>
+        private void OnSettingClicked(ClickEvent evt)
+        {
+            OutGameUIEvent.OnShownSettingScreen?.Invoke();
+        }
+
+
+        private const string STAGE_SELECT_BUTTON_NAME = "StageSelect";
+        private const string SKILL_TREE_BUTTON_NAME = "SkillTree";
+        private const string SKILL_BUILD_BUTTON_NAME = "SkillBuild";
+        private const string SETTING_BUTTON_NAME = "Setting";
+
+        private readonly Button _stageSelectButton;
+        private readonly Button _skillTreeButton;
+        private readonly Button _skillBuildButton;
+        private readonly Button _settingButton;
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/HomeScreenView.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/HomeScreenView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c2b579d983cfd4648ac41953f35ee1bf

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/IScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/IScreenView.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace KillChord.Runtime.View.OutGame.Screen
 {
     /// <summary>
-    ///     画面 のインターフェース。
+    ///     画面のインターフェース。
     /// </summary>
     public interface IScreenView
     {

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/IScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/IScreenView.cs
@@ -1,0 +1,23 @@
+namespace KillChord.Runtime.View.OutGame.Screen
+{
+    /// <summary>
+    ///     画面 のインターフェース。
+    /// </summary>
+    public interface IScreenView
+    {
+        /// <summary>
+        ///     画面を表示します。
+        /// </summary>
+        void Show();
+
+        /// <summary>
+        ///     画面を非表示にします。
+        /// </summary>
+        void Hide();
+
+        /// <summary>
+        ///     画面を即座に非表示にします。
+        /// </summary>
+        void HideImmediately();
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/IScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/IScreenView.cs
@@ -1,3 +1,6 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace KillChord.Runtime.View.OutGame.Screen
 {
     /// <summary>
@@ -8,12 +11,12 @@ namespace KillChord.Runtime.View.OutGame.Screen
         /// <summary>
         ///     画面を表示します。
         /// </summary>
-        void Show();
+        Task Show(CancellationToken token);
 
         /// <summary>
         ///     画面を非表示にします。
         /// </summary>
-        void Hide();
+        Task Hide(CancellationToken token);
 
         /// <summary>
         ///     画面を即座に非表示にします。

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/IScreenView.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/IScreenView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 51799ae506f9e6b4f95af26dffebbca8

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/OutGameUIEvent.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/OutGameUIEvent.cs
@@ -1,0 +1,66 @@
+using SymphonyFrameWork.System.ServiceLocate;
+using System;
+using UnityEngine;
+
+namespace KillChord.Runtime.View.OutGame.Screen
+{
+    /// <summary>
+    ///     アウトゲーム UI のイベントを管理するクラス。
+    ///     イベント管理クラスのため、他のクラスよりも早く初期化されるように
+    ///     DefaultExecutionOrder を -100 に設定しています。
+    /// </summary>
+    [DefaultExecutionOrder(-100)]
+    public class OutGameUIEvent : MonoBehaviour
+    {
+        /// <summary> ホーム画面を表示するイベント。 </summary>
+        public Action OnShownHomeScreen;
+
+        /// <summary> 作戦画面を表示するイベント。 </summary>
+        public Action OnShownStageSelectionScreen;
+
+        /// <summary> 研究画面を表示するイベント。 </summary>
+        public Action OnShownSkillTreeScreen;
+
+        /// <summary> 改造画面を表示するイベント。 </summary>
+        public Action OnShownSkillBuildScreen;
+
+        /// <summary> 設定画面を表示するイベント。 </summary>
+        public Action OnShownSettingScreen;
+
+        /// <summary> 画面を閉じるイベント。 </summary>
+        public Action OnScreenClosed;
+
+        /// <summary>
+        ///     アウトゲームのUIイベントを ServiceLocator に登録します。
+        /// </summary>
+        public void RegisterOutGameUIEvent()
+        {
+            ServiceLocator.RegisterInstance(this);
+        }
+
+        /// <summary>
+        ///     アウトゲームのUIイベントを ServiceLocator から登録解除します。
+        /// </summary>
+        public void UnregisterOutGameUIEvent()
+        {
+            ServiceLocator.UnregisterInstance(this);
+        }
+
+        /// <summary>
+        ///     ServiceLocator にインスタンスを登録する。
+        /// </summary>
+        private void Awake()
+        {
+            RegisterOutGameUIEvent();
+        }
+
+        /// <summary>
+        ///     ServiceLocator からインスタンスを登録解除する。
+        ///     自身で登録解除を呼び出すとエラーが起きるため、コメントアウトしています。
+        /// </summary>
+        private void OnDestroy()
+        {
+            //UnregisterOutGameUIEvent();
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/OutGameUIEvent.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/OutGameUIEvent.cs
@@ -35,7 +35,9 @@ namespace KillChord.Runtime.View.OutGame.Screen
         /// </summary>
         public void RegisterOutGameUIEvent()
         {
+            if (_isRegistered) { return; }
             ServiceLocator.RegisterInstance(this);
+            _isRegistered = true;
         }
 
         /// <summary>
@@ -43,7 +45,9 @@ namespace KillChord.Runtime.View.OutGame.Screen
         /// </summary>
         public void UnregisterOutGameUIEvent()
         {
+            if (!_isRegistered) { return; }
             ServiceLocator.UnregisterInstance(this);
+            _isRegistered = false;
         }
 
         /// <summary>
@@ -62,5 +66,7 @@ namespace KillChord.Runtime.View.OutGame.Screen
         {
             //UnregisterOutGameUIEvent();
         }
+
+        private bool _isRegistered;
     }
 }

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/OutGameUIEvent.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/OutGameUIEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8fbd60ffeeebe9343aed807180f93228

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/ScreenViewBase.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/ScreenViewBase.cs
@@ -1,0 +1,64 @@
+using System;
+using UnityEngine.UIElements;
+
+namespace KillChord.Runtime.View.OutGame.Screen
+{
+    /// <summary>
+    ///     UI Toolkit 用画面 View の規定クラス。
+    /// </summary>
+    public abstract class ScreenViewBase : IScreenView, IDisposable
+    {
+        /// <summary>
+        ///     画面 View を初期化します。
+        /// </summary>
+        public ScreenViewBase(VisualElement rootElement, OutGameUIEvent outGameUIEvent)
+        {
+            RootElement = rootElement;
+            OutGameUIEvent = outGameUIEvent;
+        }
+
+        /// <summary>
+        ///     画面を表示します。
+        /// </summary>
+        public virtual void Show()
+        {
+            RootElement.style.display = DisplayStyle.Flex;
+            RootElement.AddToClassList(VISIBLE_CLASS);
+            RootElement.RemoveFromClassList(HIDDEN_CLASS);
+            RootElement.BringToFront();
+        }
+
+        /// <summary>
+        ///     画面を非表示にします。
+        /// </summary>
+        public virtual void Hide()
+        {
+            RootElement.AddToClassList(HIDDEN_CLASS);
+            RootElement.RemoveFromClassList(VISIBLE_CLASS);
+            RootElement.style.display = DisplayStyle.None;
+        }
+
+        /// <summary>
+        ///     即座に画面を非表示にします。
+        /// </summary>
+        public virtual void HideImmediately()
+        {
+            RootElement.style.display = DisplayStyle.None;
+        }
+
+        /// <summary>
+        ///     リソースを解放します。
+        /// </summary>
+        public virtual void Dispose(){}
+
+        /// <summary> USSの画面表示用クラス名。 </summary>
+        protected const string VISIBLE_CLASS = "screen-visible";
+        /// <summary> USSの画面非表示用クラス名。 </summary>
+        protected const string HIDDEN_CLASS = "screen-hidden";
+
+        /// <summary> VisualElement のルート要素を取得します。 </summary>
+        protected VisualElement RootElement { get; }
+        /// <summary> OutGameUIEvent を取得します。 </summary>
+        protected OutGameUIEvent OutGameUIEvent { get; }
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/ScreenViewBase.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/ScreenViewBase.cs
@@ -69,7 +69,7 @@ namespace KillChord.Runtime.View.OutGame.Screen
         /// <summary>
         ///     リソースを解放します。
         /// </summary>
-        public virtual void Dispose(){}
+        public virtual void Dispose() { }
 
         /// <summary> USSの画面表示用クラス名。 </summary>
         protected const string VISIBLE_CLASS = "screen-visible";
@@ -93,21 +93,28 @@ namespace KillChord.Runtime.View.OutGame.Screen
         /// <returns></returns>
         private async Task WaitForTransitionEndAsync(CancellationToken token)
         {
-            var tcs = new TaskCompletionSource<bool>();
-
-            void OnTarnsitionEnd(TransitionEndEvent _)
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void OnTransitionEnd(TransitionEndEvent _)
             {
-                RootElement.UnregisterCallback<TransitionEndEvent>(OnTarnsitionEnd);
                 tcs.TrySetResult(true);
             }
 
-            RootElement.RegisterCallback<TransitionEndEvent>(OnTarnsitionEnd);
+            RootElement.RegisterCallback<TransitionEndEvent>(OnTransitionEnd);
+            // token がキャンセルされた時、 tcs を完了させる。
+            // これにより、キャンセルされた場合も待機が終了する。
+            using CancellationTokenRegistration registration = token.Register(() => tcs.TrySetResult(true));
 
-            await Task.WhenAny(
-                tcs.Task,
-                Task.Delay(TimeSpan.FromSeconds(TRANSITION_TIMEOUT_SEC)));
-
-            RootElement.UnregisterCallback<TransitionEndEvent>(OnTarnsitionEnd);
+            try
+            {
+                await Task.WhenAny(
+                    tcs.Task,
+                    // タイムアウトはキャンセルトークンの影響を受けないようにする。
+                    Task.Delay(TimeSpan.FromSeconds(TRANSITION_TIMEOUT_SEC), CancellationToken.None));  
+            }
+            finally
+            {
+                RootElement.UnregisterCallback<TransitionEndEvent>(OnTransitionEnd);
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/ScreenViewBase.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/ScreenViewBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using UnityEngine.UIElements;
 
 namespace KillChord.Runtime.View.OutGame.Screen
@@ -13,29 +15,47 @@ namespace KillChord.Runtime.View.OutGame.Screen
         /// </summary>
         public ScreenViewBase(VisualElement rootElement, OutGameUIEvent outGameUIEvent)
         {
+            CreateBrocker();
             RootElement = rootElement;
             OutGameUIEvent = outGameUIEvent;
+            _brocker.RemoveFromHierarchy();
         }
 
         /// <summary>
         ///     画面を表示します。
         /// </summary>
-        public virtual void Show()
+        public virtual async Task Show(CancellationToken token)
         {
+            // 画面表示中はブロッカーを配置して、ユーザーの操作を受け付けないようにする。
+            RootElement.Add(_brocker);
+
             RootElement.style.display = DisplayStyle.Flex;
             RootElement.AddToClassList(VISIBLE_CLASS);
             RootElement.RemoveFromClassList(HIDDEN_CLASS);
             RootElement.BringToFront();
+            _brocker.BringToFront();
+
+            await WaitForTransitionEndAsync(token);
+
+            _brocker.RemoveFromHierarchy();
         }
 
         /// <summary>
         ///     画面を非表示にします。
         /// </summary>
-        public virtual void Hide()
+        public virtual async Task Hide(CancellationToken token)
         {
+            // 画面非表示中はブロッカーを配置して、ユーザーの操作を受け付けないようにする。
+            RootElement.Add(_brocker);
+
             RootElement.AddToClassList(HIDDEN_CLASS);
             RootElement.RemoveFromClassList(VISIBLE_CLASS);
+            _brocker.BringToFront();
+
+            await WaitForTransitionEndAsync(token);
+
             RootElement.style.display = DisplayStyle.None;
+            _brocker.RemoveFromHierarchy();
         }
 
         /// <summary>
@@ -55,10 +75,60 @@ namespace KillChord.Runtime.View.OutGame.Screen
         protected const string VISIBLE_CLASS = "screen-visible";
         /// <summary> USSの画面非表示用クラス名。 </summary>
         protected const string HIDDEN_CLASS = "screen-hidden";
+        /// <summary> トランジションのタイムアウト秒数。 </summary>
+        protected const float TRANSITION_TIMEOUT_SEC = 1.0f;
 
         /// <summary> VisualElement のルート要素を取得します。 </summary>
         protected VisualElement RootElement { get; }
         /// <summary> OutGameUIEvent を取得します。 </summary>
         protected OutGameUIEvent OutGameUIEvent { get; }
+
+        private VisualElement _brocker;
+
+        /// <summary>
+        ///     RootElement の TransitionEnd イベントを Task に変換して待機します。
+        ///     Transition が設定されていない場合や、タイムアウト時は即座に完了します。
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        private async Task WaitForTransitionEndAsync(CancellationToken token)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+
+            void OnTarnsitionEnd(TransitionEndEvent _)
+            {
+                RootElement.UnregisterCallback<TransitionEndEvent>(OnTarnsitionEnd);
+                tcs.TrySetResult(true);
+            }
+
+            RootElement.RegisterCallback<TransitionEndEvent>(OnTarnsitionEnd);
+
+            await Task.WhenAny(
+                tcs.Task,
+                Task.Delay(TimeSpan.FromSeconds(TRANSITION_TIMEOUT_SEC)));
+
+            RootElement.UnregisterCallback<TransitionEndEvent>(OnTarnsitionEnd);
+        }
+
+        /// <summary>
+        ///     ブロッカーを生成。
+        /// </summary>
+        /// <returns></returns>
+        private void CreateBrocker()
+        {
+            // ブロッカーを生成して、画面全体を覆うように配置する。
+            _brocker = new VisualElement();
+            _brocker.style.position = Position.Absolute;
+            _brocker.style.top = 0;
+            _brocker.style.left = 0;
+            _brocker.style.right = 0;
+            _brocker.style.bottom = 0;
+
+            // ブロッカーは透明にして、ユーザーの操作を受け付けないようにする。
+            _brocker.style.backgroundColor = new UnityEngine.Color(0, 0, 0, 0.0f);
+
+            // ブロッカーがユーザーの操作を受け付ける。
+            _brocker.pickingMode = PickingMode.Position;
+        }
     }
 }

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/ScreenViewBase.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/ScreenViewBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c803c52c4dc83d4da884bc25d1a5f9c

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SettingScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SettingScreenView.cs
@@ -1,0 +1,55 @@
+using UnityEngine.UIElements;
+
+namespace KillChord.Runtime.View.OutGame.Screen
+{
+    /// <summary>
+    ///     設定画面 View です。
+    /// </summary>
+    public sealed class SettingScreenView : ScreenViewBase
+    {
+        /// <summary> View を初期化します。 </summary>
+        public SettingScreenView(VisualElement rootElement, OutGameUIEvent outGameUIEvent)
+            : base(rootElement, outGameUIEvent)
+        {
+            _backButton = rootElement.Q<Button>(BACKBUTTON_NAME)
+                ?? throw new System.ArgumentNullException(
+                    $"[{nameof(SettingScreenView)}] {_backButton} が見つかりませんでした。");
+
+            RegisterButtonCallback();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            UnregisterButtonCallback();
+        }
+
+        /// <summary>
+        ///     ボタンのコールバックを登録します。
+        /// </summary>
+        private void RegisterButtonCallback()
+        {
+            _backButton.RegisterCallback<ClickEvent>(OnBackButtonClicked);
+        }
+
+        /// <summary>
+        ///     ボタンのコールバックを解除します。
+        /// </summary>
+        private void UnregisterButtonCallback()
+        {
+            _backButton.UnregisterCallback<ClickEvent>(OnBackButtonClicked);
+        }
+
+        /// <summary>
+        ///     画面を閉じるボタンがクリックされたときの処理です。
+        /// </summary>
+        private void OnBackButtonClicked(ClickEvent evt)
+        {
+            OutGameUIEvent.OnScreenClosed?.Invoke();
+        }
+
+        private const string BACKBUTTON_NAME = "BackButton";
+
+        private readonly Button _backButton;
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SettingScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SettingScreenView.cs
@@ -13,7 +13,7 @@ namespace KillChord.Runtime.View.OutGame.Screen
         {
             _backButton = rootElement.Q<Button>(BACKBUTTON_NAME)
                 ?? throw new System.ArgumentNullException(
-                    $"[{nameof(SettingScreenView)}] {_backButton} が見つかりませんでした。");
+                    $"[{nameof(SettingScreenView)}] {BACKBUTTON_NAME} が見つかりませんでした。");
 
             RegisterButtonCallback();
         }

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SettingScreenView.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SettingScreenView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d872b582f1a825945896a6576f563179

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillBuildScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillBuildScreenView.cs
@@ -1,0 +1,56 @@
+using UnityEngine.UIElements;
+
+namespace KillChord.Runtime.View.OutGame.Screen
+{
+    /// <summary>
+    ///     スキル選択画面 View です。
+    /// </summary>
+    public sealed class SkillBuildScreenView : ScreenViewBase
+    {
+        /// <summary> View を初期化します。</summary>
+        /// <param name="rootElement"></param>
+        public SkillBuildScreenView(VisualElement rootElement, OutGameUIEvent outGameUIEvent)
+            : base(rootElement, outGameUIEvent)
+        {
+            _backButton = rootElement.Q<Button>(BACKBUTTON_NAME)
+                ?? throw new System.ArgumentNullException(
+                    $"[{nameof(SkillBuildScreenView)}] {_backButton} が見つかりませんでした。");
+
+            RegisterButtonCallback();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            UnregisterButtonCallback();
+        }
+
+        /// <summary>
+        ///     ボタンのコールバックを登録します。
+        /// </summary>
+        private void RegisterButtonCallback()
+        {
+            _backButton.RegisterCallback<ClickEvent>(OnBackButtonClicked);
+        }
+
+        /// <summary>
+        ///     ボタンのコールバックを解除します。
+        /// </summary>
+        private void UnregisterButtonCallback()
+        {
+            _backButton.UnregisterCallback<ClickEvent>(OnBackButtonClicked);
+        }
+
+        /// <summary>
+        ///     画面を閉じるボタンがクリックされたときの処理です。
+        /// </summary>
+        private void OnBackButtonClicked(ClickEvent evt)
+        {
+            OutGameUIEvent.OnScreenClosed?.Invoke();
+        }
+
+        private const string BACKBUTTON_NAME = "BackButton";
+
+        private readonly Button _backButton;
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillBuildScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillBuildScreenView.cs
@@ -14,7 +14,7 @@ namespace KillChord.Runtime.View.OutGame.Screen
         {
             _backButton = rootElement.Q<Button>(BACKBUTTON_NAME)
                 ?? throw new System.ArgumentNullException(
-                    $"[{nameof(SkillBuildScreenView)}] {_backButton} が見つかりませんでした。");
+                    $"[{nameof(SkillBuildScreenView)}] {BACKBUTTON_NAME} が見つかりませんでした。");
 
             RegisterButtonCallback();
         }

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillBuildScreenView.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillBuildScreenView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a6e635fbf28dc14190eea19985ee38b

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillTreeScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillTreeScreenView.cs
@@ -1,0 +1,55 @@
+using UnityEngine.UIElements;
+
+namespace KillChord.Runtime.View.OutGame.Screen
+{
+    /// <summary>
+    ///     研究画面 View。
+    /// </summary>
+    public sealed class SkillTreeScreenView : ScreenViewBase
+    {
+        /// <summary> View を初期化します。 </summary>
+        public SkillTreeScreenView(VisualElement rootElement, OutGameUIEvent outGameUIEvent)
+            : base(rootElement, outGameUIEvent)
+        {
+            _backButton = rootElement.Q<Button>(BACKBUTTON_NAME)
+                ?? throw new System.ArgumentNullException(
+                    $"[{nameof(SkillTreeScreenView)}] {_backButton} が見つかりませんでした。");
+
+            RegisterButtonCallback();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            UnregisterButtonCallback();
+        }
+
+        /// <summary>
+        ///     ボタンのコールバックを登録します。
+        /// </summary>
+        private void RegisterButtonCallback()
+        {
+            _backButton.RegisterCallback<ClickEvent>(OnBackButtonClicked);
+        }
+
+        /// <summary>
+        ///     ボタンのコールバックを解除します。
+        /// </summary>
+        private void UnregisterButtonCallback()
+        {
+            _backButton.UnregisterCallback<ClickEvent>(OnBackButtonClicked);
+        }
+
+        /// <summary>
+        ///     画面を閉じるボタンがクリックされたときの処理です。
+        /// </summary>
+        private void OnBackButtonClicked(ClickEvent evt)
+        {
+            OutGameUIEvent.OnScreenClosed?.Invoke();
+        }
+
+        private const string BACKBUTTON_NAME = "BackButton";
+
+        private readonly Button _backButton;
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillTreeScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillTreeScreenView.cs
@@ -13,7 +13,7 @@ namespace KillChord.Runtime.View.OutGame.Screen
         {
             _backButton = rootElement.Q<Button>(BACKBUTTON_NAME)
                 ?? throw new System.ArgumentNullException(
-                    $"[{nameof(SkillTreeScreenView)}] {_backButton} が見つかりませんでした。");
+                    $"[{nameof(SkillTreeScreenView)}] {BACKBUTTON_NAME} が見つかりませんでした。");
 
             RegisterButtonCallback();
         }

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillTreeScreenView.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/SkillTreeScreenView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fe6d511521d728d4ba4d5422e6e98ba8

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/StageSelectScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/StageSelectScreenView.cs
@@ -13,7 +13,7 @@ namespace KillChord.Runtime.View.OutGame.Screen
         {
             _backButton = rootElement.Q<Button>(BACKBUTTON_NAME)
                 ?? throw new System.ArgumentNullException(
-                    $"[{nameof(StageSelectScreenView)}] {_backButton} が見つかりませんでした。");
+                    $"[{nameof(StageSelectScreenView)}] {BACKBUTTON_NAME} が見つかりませんでした。");
 
             RegisterButtonCallback();
         }

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/StageSelectScreenView.cs
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/StageSelectScreenView.cs
@@ -1,0 +1,55 @@
+using UnityEngine.UIElements;
+
+namespace KillChord.Runtime.View.OutGame.Screen
+{
+    /// <summary>
+    ///     作戦画面 View。
+    /// </summary>
+    public sealed class StageSelectScreenView : ScreenViewBase
+    {
+        /// <summary> View を初期化します。 </summary>
+        public StageSelectScreenView(VisualElement rootElement, OutGameUIEvent outGameUIEvent)
+            : base(rootElement, outGameUIEvent)
+        {
+            _backButton = rootElement.Q<Button>(BACKBUTTON_NAME)
+                ?? throw new System.ArgumentNullException(
+                    $"[{nameof(StageSelectScreenView)}] {_backButton} が見つかりませんでした。");
+
+            RegisterButtonCallback();
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            UnregisterButtonCallback();
+        }
+
+        /// <summary>
+        ///     ボタンのコールバックを登録します。
+        /// </summary>
+        private void RegisterButtonCallback()
+        {
+            _backButton.RegisterCallback<ClickEvent>(OnBackButtonClicked);
+        }
+
+        /// <summary>
+        ///     ボタンのコールバックを解除します。
+        /// </summary>
+        private void UnregisterButtonCallback()
+        {
+            _backButton.UnregisterCallback<ClickEvent>(OnBackButtonClicked);
+        }
+
+        /// <summary>
+        ///     画面を閉じるボタンがクリックされたときの処理です。
+        /// </summary>
+        private void OnBackButtonClicked(ClickEvent evt)
+        {
+            OutGameUIEvent.OnScreenClosed?.Invoke();
+        }
+
+        private const string BACKBUTTON_NAME = "BackButton";
+
+        private readonly Button _backButton;
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/OutGame/Screen/StageSelectScreenView.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/OutGame/Screen/StageSelectScreenView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: baa0d3d12b582b94abdb26e18c74b86b

--- a/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen.meta
+++ b/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87e5b38baf039c74f90fc8516f2db054
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleData.cs
+++ b/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleData.cs
@@ -1,0 +1,45 @@
+using JetBrains.Annotations;
+using KillChord.Runtime.Domain.OutGame.Screen;
+using System;
+using System.Security.Cryptography.X509Certificates;
+using UnityEngine;
+
+namespace KillChord.Runtime.InfraStructure.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移ルールデータ。
+    /// </summary>
+    [CreateAssetMenu(fileName = "ScreenRuleData", menuName = "KillChord/OutGame/ScreenRuleData")]
+    public sealed class ScreenRuleData : ScriptableObject
+    {
+        /// <summary> 画面遷移ルールエントリの一覧。 </summary>
+        [SerializeField, Tooltip("画面ごとの遷移ルール一覧。")]
+        private ScreenRuleEntry[] _entries = Array.Empty<ScreenRuleEntry>();
+
+        /// <summary> 画面遷移ルールエントリの一覧を取得します。 </summary>
+        public ScreenRuleEntry[] Entries => _entries;
+
+        /// <summary>
+        ///     画面遷移ルールエントリ。
+        /// </summary>
+        [Serializable]
+        public struct ScreenRuleEntry
+        {
+            [SerializeField, Tooltip("対象の画面 ID。")]
+            private ScreenId _screenId;
+
+            [SerializeField, Tooltip("遷移タイプ。")]
+            private ScreenTransitionType _transitionType;
+
+            [SerializeField, Tooltip("履歴に追加するかどうか。")]
+            private bool _isAddToHistory;
+
+            /// <summary> 対象の画面 ID を取得します。 </summary>
+            public ScreenId ScreenId => _screenId;
+            /// <summary> 遷移タイプを取得します。 </summary>
+            public ScreenTransitionType TransitionType => _transitionType;
+            /// <summary> 履歴に追加するかどうかを取得します。 </summary>
+            public bool IsAddToHistory => _isAddToHistory;
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleData.cs.meta
+++ b/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 41cad7e54781c7345972795165c96e61

--- a/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleRepository.cs
+++ b/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleRepository.cs
@@ -1,0 +1,33 @@
+using KillChord.Runtime.Application.OutGame.Screen;
+using KillChord.Runtime.Domain.OutGame.Screen;
+using System.Collections.Generic;
+
+namespace KillChord.Runtime.InfraStructure.OutGame.Screen
+{
+    /// <summary>
+    ///     画面遷移ルールリポジトリクラス。
+    /// </summary>
+    public sealed class ScreenRuleRepository : IScreenRuleRepository
+    {
+        /// <summary>
+        ///     画面遷移ルールリポジトリを初期化します。
+        /// </summary>
+        public ScreenRuleRepository(ScreenRuleData data)
+        {
+            foreach (var entry in data.Entries)
+            {
+                _rules[entry.ScreenId] = new ScreenTransitionRule(entry.TransitionType, entry.IsAddToHistory);
+            }
+        }
+
+        /// <summary>
+        ///     指定画面の遷移ルールを取得します。
+        /// </summary>
+        public ScreenTransitionRule GetRule(ScreenId screenId)
+        {
+            return _rules[screenId];
+        }
+
+        private readonly Dictionary<ScreenId, ScreenTransitionRule> _rules = new();
+    }
+}

--- a/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleRepository.cs
+++ b/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleRepository.cs
@@ -1,5 +1,6 @@
 using KillChord.Runtime.Application.OutGame.Screen;
 using KillChord.Runtime.Domain.OutGame.Screen;
+using System;
 using System.Collections.Generic;
 
 namespace KillChord.Runtime.InfraStructure.OutGame.Screen
@@ -14,18 +15,34 @@ namespace KillChord.Runtime.InfraStructure.OutGame.Screen
         /// </summary>
         public ScreenRuleRepository(ScreenRuleData data)
         {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data));
+            }
+
+            if (data.Entries == null)
+            {
+                throw new ArgumentNullException(nameof(data.Entries));
+            }
+
             foreach (var entry in data.Entries)
             {
-                _rules[entry.ScreenId] = new ScreenTransitionRule(entry.TransitionType, entry.IsAddToHistory);
+                if (!_rules.TryAdd(entry.ScreenId, new ScreenTransitionRule(entry.TransitionType, entry.IsAddToHistory)))
+                {
+                    throw new InvalidOperationException($"Duplicate ScreenId rule detected: {entry.ScreenId}");
+                }
             }
         }
-
         /// <summary>
         ///     指定画面の遷移ルールを取得します。
         /// </summary>
         public ScreenTransitionRule GetRule(ScreenId screenId)
         {
-            return _rules[screenId];
+            if (_rules.TryGetValue(screenId, out var rule))
+            {
+                return rule;
+            }
+            throw new KeyNotFoundException($"Screen transition rule is not defined for: {screenId}");
         }
 
         private readonly Dictionary<ScreenId, ScreenTransitionRule> _rules = new();

--- a/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleRepository.cs.meta
+++ b/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenRuleRepository.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4dcba710200ee749b147d02c056699f

--- a/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenStateRepository.cs
+++ b/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenStateRepository.cs
@@ -1,0 +1,13 @@
+using KillChord.Runtime.Application.OutGame.Screen;
+
+namespace KillChord.Runtime.InfraStructure.OutGame.Screen
+{
+    /// <summary>
+    ///     画面状態リポジトリクラス。
+    /// </summary>
+    public sealed class ScreenStateRepository : IScreenStateRepository
+    {
+        /// <summary> 画面遷移状態を取得します。 </summary>
+        public ScreenTransitionState TransitionState { get; } = new();
+    }
+}

--- a/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenStateRepository.cs.meta
+++ b/Assets/Scripts/Runtime/5.InfraStructure/OutGame/Screen/ScreenStateRepository.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 50f446593581821488a94c73b281c781

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen.meta
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4fe33e842c3349e409f4f2d6826c19f6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs
@@ -61,14 +61,53 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
                 return;
             }
 
+            if (_screenRuleData == null)
+            {
+                Debug.LogError($"[{nameof(ScreenInitializer)}] ScreenRuleData が設定されていません。", this);
+                return;
+            }
+
             // View 層
             VisualElement rootElement = _uiDocument.rootVisualElement;
 
-            HomeScreenView homeScreenView = new(rootElement.Q<VisualElement>(HOMESCREEN_NAME), _outGameUIEvent);
-            StageSelectScreenView stageSelectScreenView = new(rootElement.Q<VisualElement>(STAGESELECTSCREEN_NAME), _outGameUIEvent);
-            SkillTreeScreenView skillTreeScreenView = new(rootElement.Q<VisualElement>(SKILLTREESCREEN_NAME), _outGameUIEvent);
-            SkillBuildScreenView skillBuildScreenView = new(rootElement.Q<VisualElement>(SKILLBUILDSCREEN_NAME), _outGameUIEvent);
-            SettingScreenView settingScreenView = new(rootElement.Q<VisualElement>(SETTINGSCREEN_NAME), _outGameUIEvent);
+            VisualElement homeRoot = rootElement.Q<VisualElement>(HOMESCREEN_NAME);
+            VisualElement stageSelectRott = rootElement.Q<VisualElement>(STAGESELECTSCREEN_NAME);
+            VisualElement skillTreeRoot = rootElement.Q<VisualElement>(SKILLTREESCREEN_NAME);
+            VisualElement skillBuildRoot = rootElement.Q<VisualElement>(SKILLBUILDSCREEN_NAME);
+            VisualElement settingRoot = rootElement.Q<VisualElement>(SETTINGSCREEN_NAME);
+
+            // 各画面のルート要素が見つからない場合は、エラーログを出力して初期化を中断します。
+            if (homeRoot == null)
+            {
+                Debug.LogError($"[{nameof(ScreenInitializer)}] {HOMESCREEN_NAME} が見つかりませんでした。", this);
+                return;
+            }
+            if (stageSelectRott == null)
+            {
+                Debug.LogError($"[{nameof(ScreenInitializer)}] {STAGESELECTSCREEN_NAME} が見つかりませんでした。", this); 
+                return;
+            }
+            if (skillTreeRoot == null)
+            {
+                Debug.LogError($"[{nameof(ScreenInitializer)}] {SKILLTREESCREEN_NAME} が見つかりませんでした。", this);
+                return;
+            }
+            if (skillBuildRoot == null)
+            {
+                Debug.LogError($"[{nameof(ScreenInitializer)}] {SKILLBUILDSCREEN_NAME} が見つかりませんでした。", this);
+                return;
+            }
+            if (settingRoot == null)
+            {
+                Debug.LogError($"[{nameof(ScreenInitializer)}] {SETTINGSCREEN_NAME} が見つかりませんでした。", this);
+                return;
+            }
+
+            HomeScreenView homeScreenView = new HomeScreenView(homeRoot, _outGameUIEvent);
+            StageSelectScreenView stageSelectScreenView = new StageSelectScreenView(stageSelectRott, _outGameUIEvent);
+            SkillTreeScreenView skillTreeScreenView = new SkillTreeScreenView(skillTreeRoot, _outGameUIEvent);
+            SkillBuildScreenView skillBuildScreenView = new SkillBuildScreenView(skillBuildRoot, _outGameUIEvent);
+            SettingScreenView settingScreenView = new SettingScreenView(settingRoot, _outGameUIEvent);
 
             ScreenViewRegistry screenViewRegistry = new(
                 homeScreenView,
@@ -110,7 +149,7 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
             _ctsShow = new();
             _ctsHide = new();
 
-            _ = _screenController.ShowHome(_ctsShow.Token);
+            _transitionTask = _screenController.ShowHome(_ctsShow.Token);
             _isInitialized = true;
         }
 

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs
@@ -35,7 +35,7 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         private void OnDisable()
         {
             Unsubscribe();
-            _screenViewRegistry.Dispose();
+            _screenViewRegistry?.Dispose();
         }
 
         /// <summary>

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs
@@ -1,0 +1,204 @@
+using KillChord.Runtime.Adaptor.OutGame.Screen;
+using KillChord.Runtime.Application.OutGame.Screen;
+using KillChord.Runtime.InfraStructure.OutGame.Screen;
+using KillChord.Runtime.View.OutGame.Screen;
+using SymphonyFrameWork.System.ServiceLocate;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace KillChord.Runtime.Composition.OutGame.Screen
+{
+    /// <summary>
+    ///     アウトゲーム画面の依存を解決するクラス。
+    /// </summary>
+    public sealed class ScreenInitializer : MonoBehaviour
+    {
+        /// <summary>
+        ///     初期化を行います。
+        /// </summary>
+        private void Awake()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        ///     イベント購読を行います。
+        /// </summary>
+        private void OnEnable()
+        {
+            Subscribe();
+        }
+
+        /// <summary>
+        ///     イベント購読解除を行います。
+        /// </summary>
+        private void OnDisable()
+        {
+            Unsubscribe();
+            _screenViewRegistry.Dispose();
+        }
+
+        /// <summary>
+        ///     システムを構築します。
+        /// </summary>
+        private void Initialize()
+        {
+            _outGameUIEvent = ServiceLocator.GetInstance<OutGameUIEvent>();
+            if (_outGameUIEvent == null)
+            {
+                Debug.LogError($"[{nameof(ScreenInitializer)}] OutGameUIEvent が取得できませんでした.", this);
+                return;
+            }
+
+            if (_uiDocument == null)
+            {
+                Debug.LogError($"[{nameof(ScreenInitializer)}] UIDocument が設定されていません。", this);
+                return;
+            }
+
+            // View 層
+            VisualElement rootElement = _uiDocument.rootVisualElement;
+
+            HomeScreenView homeScreenView = new(rootElement.Q<VisualElement>(HOMESCREEN_NAME), _outGameUIEvent);
+            StageSelectScreenView stageSelectScreenView = new(rootElement.Q<VisualElement>(STAGESELECTSCREEN_NAME), _outGameUIEvent);
+            SkillTreeScreenView skillTreeScreenView = new(rootElement.Q<VisualElement>(SKILLTREESCREEN_NAME), _outGameUIEvent);
+            SkillBuildScreenView skillBuildScreenView = new(rootElement.Q<VisualElement>(SKILLBUILDSCREEN_NAME), _outGameUIEvent);
+            SettingScreenView settingScreenView = new(rootElement.Q<VisualElement>(SETTINGSCREEN_NAME), _outGameUIEvent);
+
+            ScreenViewRegistry screenViewRegistry = new(
+                homeScreenView,
+                stageSelectScreenView,
+                skillTreeScreenView,
+                skillBuildScreenView,
+                settingScreenView);
+
+            _screenViewRegistry = screenViewRegistry;
+            screenViewRegistry.HideAllImmediately();
+
+            // InfraStructure 層
+            IScreenStateRepository screenStateRepository = new ScreenStateRepository();
+            IScreenRuleRepository screenRuleRepository = new ScreenRuleRepository(_screenRuleData);
+
+            //  Adaptor 層
+            IScreenTransitionApplicable screenViewModel = new ScreenViewApplicator(screenViewRegistry);
+            IScreenPresenter screenPresenter = new ScreenPresenter(screenViewModel);
+
+            // Application 層
+            ShowScreenUseCase showScreenUseCase = new(
+                screenStateRepository,
+                screenRuleRepository,
+                screenPresenter);
+
+            CloseCurrentScreenUseCase closeCurrentScreenUseCase = new(
+                screenStateRepository,
+                screenPresenter);
+
+            ResetToHomeScreenUseCase resetToHomeScreenUseCase = new(
+                screenStateRepository,
+                screenPresenter);
+
+            _screenController = new(
+                showScreenUseCase,
+                closeCurrentScreenUseCase,
+                resetToHomeScreenUseCase);
+
+            _screenController.ShowHome();
+            _isInitialized = true;
+        }
+
+        /// <summary>
+        ///     UI イベントを購読します。
+        /// </summary>
+        private void Subscribe()
+        {
+            if (!_isInitialized) { return; }
+            _outGameUIEvent.OnShownHomeScreen += HandleHomeScreenShown;
+            _outGameUIEvent.OnShownStageSelectionScreen += HandleStageSelectionScreenShown;
+            _outGameUIEvent.OnShownSkillTreeScreen += HandleSkillTreeScreenShown;
+            _outGameUIEvent.OnShownSkillBuildScreen += HandleSkillBuildScreenShown;
+            _outGameUIEvent.OnShownSettingScreen += HandleSettingsShown;
+            _outGameUIEvent.OnScreenClosed += HandleScreenClosed;
+        }
+
+        /// <summary>
+        ///     UI イベント購読を解除します。
+        /// </summary>
+        private void Unsubscribe()
+        {
+            if (!_isInitialized) { return; }
+            _outGameUIEvent.OnShownHomeScreen -= HandleHomeScreenShown;
+            _outGameUIEvent.OnShownStageSelectionScreen -= HandleStageSelectionScreenShown;
+            _outGameUIEvent.OnShownSkillTreeScreen -= HandleSkillTreeScreenShown;
+            _outGameUIEvent.OnShownSkillBuildScreen -= HandleSkillBuildScreenShown;
+            _outGameUIEvent.OnShownSettingScreen -= HandleSettingsShown;
+            _outGameUIEvent.OnScreenClosed -= HandleScreenClosed;
+
+            _outGameUIEvent.UnregisterOutGameUIEvent();
+        }
+
+        /// <summary>
+        ///     ホーム画面表示イベントを処理します。
+        /// </summary>
+        private void HandleHomeScreenShown()
+        {
+            _screenController.ShowHome();
+        }
+
+        /// <summary>
+        ///     ステージ選択表示イベントを処理します。
+        /// </summary>
+        private void HandleStageSelectionScreenShown()
+        {
+            _screenController.ShowStageSelect();
+        }
+
+        /// <summary>
+        ///     スキルツリー表示イベントを処理します。
+        /// </summary>
+        private void HandleSkillTreeScreenShown()
+        {
+            _screenController.ShowSkillTree();
+        }
+
+        /// <summary>
+        ///     スキル選択表示イベントを処理します。
+        /// </summary>
+        private void HandleSkillBuildScreenShown()
+        {
+            _screenController.ShowSkillBuild();
+        }
+
+        /// <summary>
+        ///     設定表示イベントを処理します。
+        /// </summary>
+        private void HandleSettingsShown()
+        {
+            _screenController.ShowSetting();
+        }
+
+        /// <summary>
+        ///     画面クローズイベントを処理します。
+        /// </summary>
+        private void HandleScreenClosed()
+        {
+            _screenController.CloseCurrent();
+        }
+
+        private const string HOMESCREEN_NAME = "HomeContainer";
+        private const string STAGESELECTSCREEN_NAME = "StageSelectContainer";
+        private const string SKILLTREESCREEN_NAME = "SkillTreeContainer";
+        private const string SKILLBUILDSCREEN_NAME = "SkillBuildContainer";
+        private const string SETTINGSCREEN_NAME = "SettingContainer";
+
+        [SerializeField]
+        [Tooltip("画面表示に使用する UIDocument です。")]
+        private UIDocument _uiDocument;
+        [SerializeField, Tooltip("画面遷移ルールデータです。")]
+        private ScreenRuleData _screenRuleData;
+
+        private ScreenController _screenController;
+        private OutGameUIEvent _outGameUIEvent;
+        private ScreenViewRegistry _screenViewRegistry;
+        private bool _isInitialized = false;
+    }
+}

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs
@@ -3,6 +3,8 @@ using KillChord.Runtime.Application.OutGame.Screen;
 using KillChord.Runtime.InfraStructure.OutGame.Screen;
 using KillChord.Runtime.View.OutGame.Screen;
 using SymphonyFrameWork.System.ServiceLocate;
+using System.Threading;
+using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -36,6 +38,9 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         {
             Unsubscribe();
             _screenViewRegistry?.Dispose();
+
+            CancelAndDispose(ref _ctsShow);
+            CancelAndDispose(ref _ctsHide);
         }
 
         /// <summary>
@@ -102,7 +107,10 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
                 closeCurrentScreenUseCase,
                 resetToHomeScreenUseCase);
 
-            _screenController.ShowHome();
+            _ctsShow = new();
+            _ctsHide = new();
+
+            _ = _screenController.ShowHome(_ctsShow.Token);
             _isInitialized = true;
         }
 
@@ -141,7 +149,10 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         /// </summary>
         private void HandleHomeScreenShown()
         {
-            _screenController.ShowHome();
+            // 前回の画面の表示が完了していない場合は、完了するまで待機します。
+            if (IsTransitioning) { return; }
+
+            _transitionTask = _screenController.ShowHome(RenewShowToken());
         }
 
         /// <summary>
@@ -149,7 +160,10 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         /// </summary>
         private void HandleStageSelectionScreenShown()
         {
-            _screenController.ShowStageSelect();
+            // 前回の画面の表示が完了していない場合は、完了するまで待機します。
+            if (IsTransitioning) { return; }
+
+            _transitionTask = _screenController.ShowStageSelect(RenewShowToken());
         }
 
         /// <summary>
@@ -157,7 +171,10 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         /// </summary>
         private void HandleSkillTreeScreenShown()
         {
-            _screenController.ShowSkillTree();
+            // 前回の画面の表示が完了していない場合は、完了するまで待機します。
+            if (IsTransitioning) { return; }
+
+            _transitionTask = _screenController.ShowSkillTree(RenewShowToken());
         }
 
         /// <summary>
@@ -165,7 +182,10 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         /// </summary>
         private void HandleSkillBuildScreenShown()
         {
-            _screenController.ShowSkillBuild();
+            // 前回の画面の表示が完了していない場合は、完了するまで待機します。
+            if (IsTransitioning) { return; }
+
+            _transitionTask = _screenController.ShowSkillBuild(RenewShowToken());
         }
 
         /// <summary>
@@ -173,7 +193,10 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         /// </summary>
         private void HandleSettingsShown()
         {
-            _screenController.ShowSetting();
+            // 前回の画面の表示が完了していない場合は、完了するまで待機します。
+            if (IsTransitioning) { return; }
+
+            _transitionTask = _screenController.ShowSetting(RenewShowToken());
         }
 
         /// <summary>
@@ -181,7 +204,43 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         /// </summary>
         private void HandleScreenClosed()
         {
-            _screenController.CloseCurrent();
+            // 前回の画面の非表示が完了していない場合は、完了するまで待機します。
+            if (IsTransitioning) { return; }
+
+            _transitionTask = _screenController.CloseCurrent(RenewHideToken());
+        }
+
+        /// <summary>
+        ///     Task のキャンセルと新しい CancellationTokenSource の生成を行います。
+        /// </summary>
+        /// <returns> 新しい CancellationToken を返します。 </returns>
+        private CancellationToken RenewShowToken()
+        {
+            CancelAndDispose(ref _ctsShow);
+            _ctsShow = new();
+            return _ctsShow.Token;
+        }
+
+        /// <summary>
+        ///     Task のキャンセルと新しい CancellationTokenSource の生成を行います。
+        /// </summary>
+        /// <returns> 新しい CancellationToken を返します。 </returns>
+        private CancellationToken RenewHideToken()
+        {
+            CancelAndDispose(ref _ctsHide);
+            _ctsHide = new();
+            return _ctsHide.Token;
+        }
+
+        /// <summary>
+        ///     CancellationTokenSource をキャンセルし、破棄します。
+        ///     さらに、参照を null に設定します。
+        /// </summary>
+        private void CancelAndDispose(ref CancellationTokenSource cts)
+        {
+            cts?.Cancel();
+            cts?.Dispose();
+            cts = null;
         }
 
         private const string HOMESCREEN_NAME = "HomeContainer";
@@ -195,10 +254,16 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         private UIDocument _uiDocument;
         [SerializeField, Tooltip("画面遷移ルールデータです。")]
         private ScreenRuleData _screenRuleData;
+        private bool IsTransitioning => _transitionTask != null && !_transitionTask.IsCompleted;
 
         private ScreenController _screenController;
         private OutGameUIEvent _outGameUIEvent;
         private ScreenViewRegistry _screenViewRegistry;
         private bool _isInitialized = false;
+
+        private Task _transitionTask;
+
+        private CancellationTokenSource _ctsShow;
+        private CancellationTokenSource _ctsHide;
     }
 }

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs.meta
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenInitializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d2b280857c6f6da49a9e45994f548fc0

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenViewRegistry.cs
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenViewRegistry.cs
@@ -1,0 +1,72 @@
+using KillChord.Runtime.Adaptor.OutGame.Screen;
+using KillChord.Runtime.Domain.OutGame.Screen;
+using KillChord.Runtime.View.OutGame.Screen;
+using System;
+using System.Collections.Generic;
+
+namespace KillChord.Runtime.Composition.OutGame.Screen
+{
+    /// <summary>
+    ///     画面 ID と View の対応表クラス。
+    /// </summary>
+    public sealed class ScreenViewRegistry : IScreenViewRegistry, IDisposable
+    {
+        /// <summary> Registry を初期化します。 </summary>
+        public ScreenViewRegistry(
+            ScreenViewBase homeScreenView,
+            ScreenViewBase stageSelectScreenView,
+            ScreenViewBase skillTreeScreenView,
+            ScreenViewBase skillSelectScreenView,
+            ScreenViewBase settingScreenView)
+        {
+            _views = new Dictionary<ScreenId, ScreenViewBase>
+            {
+                { ScreenId.Home, homeScreenView },
+                { ScreenId.StageSelect, stageSelectScreenView },
+                { ScreenId.SkillTree, skillTreeScreenView },
+                { ScreenId.SkillBuild, skillSelectScreenView },
+                { ScreenId.Setting, settingScreenView },
+            };
+        }
+
+        /// <summary>
+        ///     指定画面を表示します。
+        /// </summary>
+        public void Show(ScreenId screenId)
+        {
+            _views[screenId].Show();
+        }
+
+        /// <summary>
+        ///     指定画面を非表示にします。
+        /// </summary>
+        public void Hide(ScreenId screenId)
+        {
+            _views[screenId].Hide();
+        }
+
+        /// <summary>
+        ///     全画面を即時非表示にします。
+        /// </summary>
+        public void HideAllImmediately()
+        {
+            foreach (IScreenView screenView in _views.Values)
+            {
+                screenView.HideImmediately();
+            }
+        }
+
+        /// <summary>
+        ///     レジストリに登録されている全ての画面のリソースを解放します。
+        /// </summary>
+        public void Dispose()
+        {
+            foreach(IDisposable disposable in _views.Values)
+            {
+                disposable.Dispose();
+            }
+        }
+
+        private readonly IReadOnlyDictionary<ScreenId, ScreenViewBase> _views;
+    }
+}

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenViewRegistry.cs
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenViewRegistry.cs
@@ -3,6 +3,8 @@ using KillChord.Runtime.Domain.OutGame.Screen;
 using KillChord.Runtime.View.OutGame.Screen;
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace KillChord.Runtime.Composition.OutGame.Screen
 {
@@ -30,19 +32,19 @@ namespace KillChord.Runtime.Composition.OutGame.Screen
         }
 
         /// <summary>
-        ///     指定画面を表示します。
+        ///     指定画面を表示し、トランジションの完了を待機します。
         /// </summary>
-        public void Show(ScreenId screenId)
+        public async Task Show(ScreenId screenId, CancellationToken token)
         {
-            _views[screenId].Show();
+            await _views[screenId].Show(token);
         }
 
         /// <summary>
-        ///     指定画面を非表示にします。
+        ///     指定画面を非表示にし、トランジションの完了を待機します。
         /// </summary>
-        public void Hide(ScreenId screenId)
+        public async Task Hide(ScreenId screenId, CancellationToken token)
         {
-            _views[screenId].Hide();
+            await _views[screenId].Hide(token);
         }
 
         /// <summary>

--- a/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenViewRegistry.cs.meta
+++ b/Assets/Scripts/Runtime/6.Composition/OutGame/Screen/ScreenViewRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 853ac1771e5818f46a213e9771a59383


### PR DESCRIPTION
## 各画面の実装
UI Toolkit を使用。
- ホーム画面
- 作戦画面
- 研究画面
- 改造画面
- 設定画面

## 画面遷移の実装
- ホーム画面から各画面への遷移。
- 各画面からホーム画面に戻る。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * アウトゲームの画面遷移システムを追加（ホーム／作戦／研究／改造／設定）
  * 各画面のUIsと共通スタイル、ホバーアニメーションを導入
  * 初期ホーム表示、画面の表示・非表示切替（アニメーション対応）
  * 戻る／閉じる操作と遷移履歴の管理（戻るで前画面へ復帰）
  * 画面操作用のコントローラとイベント連携でボタン操作を統合
<!-- end of auto-generated comment: release notes by coderabbit.ai -->