### PR TITLE
ニュートラル入力時の回避

### DIFF
--- a/Assets/Scripts/Runtime/4.View/InGame/Player/PlayerView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Player/PlayerView.cs
@@ -160,6 +160,12 @@ namespace KillChord.Runtime.View.InGame.Player
 
             if (_isDodge)
             {
+                // 移動入力がない場合は、前方を回避方向とする
+                if (dir.sqrMagnitude <= float.Epsilon)
+                {
+                    var fwd = _cacheTransform.forward;
+                    dir = new Vector2(fwd.x, fwd.z).normalized;
+                }
                 _controller.TryDodge(dir, Time.time);
                 _isDodge = false;
             }

--- a/Assets/Scripts/Runtime/4.View/InGame/Player/PlayerView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Player/PlayerView.cs
@@ -164,7 +164,8 @@ namespace KillChord.Runtime.View.InGame.Player
                 if (dir.sqrMagnitude <= float.Epsilon)
                 {
                     var fwd = _cacheTransform.forward;
-                    dir = new Vector2(fwd.x, fwd.z).normalized;
+                    dir.x = fwd.x;
+                    dir.y = fwd.z;
                 }
                 _controller.TryDodge(dir, Time.time);
                 _isDodge = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* プレイヤーが移動入力なしで回避を実行する際の処理を改善しました。キャラクターが向いている方向を基準として使用することで、回避がより確実に機能するようになります。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HIBIKI5201/SymphonyKillChord/pull/594)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->