### PR TITLE
[fix]セッティングの保存パスの間違いを修正

### DIFF
--- a/Assets/Editor/Scripts/AutoBuilder/AutoBuilderSettings.cs
+++ b/Assets/Editor/Scripts/AutoBuilder/AutoBuilderSettings.cs
@@ -9,7 +9,7 @@ namespace KillChord.Editor.AutoBuilder
     ///     オートビルダーの設定を保持するクラス。
     /// </summary>
     [FilePath(
-        ProviderConst.PROJECT_PATH + nameof(AutoBuilderSettings) + ProviderConst.ASSET_EXT,
+        ProviderConst.USER_SETTINGS_PATH + nameof(AutoBuilderSettings) + ProviderConst.ASSET_EXT,
         FilePathAttribute.Location.ProjectFolder)]
     public class AutoBuilderSettings : ScriptableSingleton<AutoBuilderSettings>
     {

--- a/ProjectSettings/KillChord/AutoBuilderSettings.asset
+++ b/ProjectSettings/KillChord/AutoBuilderSettings.asset
@@ -18,5 +18,5 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 718556651b4db624aa295a29d17b95f0, type: 2}
   DevelopPath: Build/Dev/
   DevelopBuildProfiles:
-  - {fileID: 0}
+  - {fileID: 11400000, guid: ec564668221479542b778d87ad6ee300, type: 2}
   - {fileID: 11400000, guid: e1201efd627c4bd4892d9d572a8da719, type: 2}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * AutoBuilder設定ファイルの保存位置を変更しました。プロジェクトディレクトリからユーザー設定ディレクトリへ移動されます。これにより、設定の管理がより効率的になります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HIBIKI5201/SymphonyKillChord/pull/611)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->