### PR TITLE
ジャスト判定を攻撃コンテキストに渡す対応

### DIFF
--- a/Assets/Scripts/Runtime/1.Domain/InGame/Battle/AttackDefinition.cs
+++ b/Assets/Scripts/Runtime/1.Domain/InGame/Battle/AttackDefinition.cs
@@ -15,7 +15,8 @@ namespace KillChord.Runtime.Domain.InGame.Battle
             Damage baseDamage,
             AttackParameterSet attackParameterSet,
             IAttackPipeline attackPipeline,
-            BeatType? beatType = null
+            BeatType? beatType = null,
+            float justDamageMultiplier = 1.0f
             )
         {
             AttackName = attackName;
@@ -23,6 +24,7 @@ namespace KillChord.Runtime.Domain.InGame.Battle
             AttackParameterSet = attackParameterSet;
             AttackPipeline = attackPipeline;
             BeatType = beatType;
+            JustDamageMultiplier = justDamageMultiplier;
         }
 
         /// <summary> 攻撃の名前を表すプロパティ。 </summary>
@@ -36,5 +38,7 @@ namespace KillChord.Runtime.Domain.InGame.Battle
 
         /// <summary> 対応するビートタイプを取得する。 </summary>
         public BeatType? BeatType { get; }
+
+        public float JustDamageMultiplier { get; }
     }
 }

--- a/Assets/Scripts/Runtime/1.Domain/InGame/Battle/AttackStepContext.cs
+++ b/Assets/Scripts/Runtime/1.Domain/InGame/Battle/AttackStepContext.cs
@@ -12,13 +12,14 @@ namespace KillChord.Runtime.Domain.InGame.Battle
         /// <param name="attackDefinition"></param>
         /// <param name="attacker"></param>
         /// <param name="defender"></param>
-        public AttackStepContext(AttackDefinition attackDefinition, IAttacker attacker, IDefender defender)
+        public AttackStepContext(AttackDefinition attackDefinition, IAttacker attacker, IDefender defender, bool isJustHit = false)
         {
             _attackDefinition = attackDefinition;
             _damage = attackDefinition.BaseDamage;
             _criticalCount = 0;
             _attacker = attacker;
             _defender = defender;
+            _isJustHit = isJustHit;
         }
 
         /// <summary>
@@ -35,6 +36,7 @@ namespace KillChord.Runtime.Domain.InGame.Battle
             _criticalCount = criticalCount;
             _attacker = attackStepContext._attacker;
             _defender = attackStepContext._defender;
+            _isJustHit = attackStepContext._isJustHit;
         }
 
         /// <summary> 攻撃定義を取得する。 </summary>
@@ -51,11 +53,14 @@ namespace KillChord.Runtime.Domain.InGame.Battle
 
         /// <summary> 防御者を取得する。 </summary>
         public IDefender Defender => _defender;
-
+        
+        /// <summary> リズムゲームのジャストタイミングで攻撃がヒットしたかを取得する。</summary>
+        public bool IsJustHit => _isJustHit;
         private readonly AttackDefinition _attackDefinition;
         private readonly Damage _damage;
         private readonly int _criticalCount;
         private readonly IAttacker _attacker;
         private readonly IDefender _defender;
+        private readonly bool _isJustHit;
     }
 }

--- a/Assets/Scripts/Runtime/2.Application/InGame/Battle/AttackCalculator.cs
+++ b/Assets/Scripts/Runtime/2.Application/InGame/Battle/AttackCalculator.cs
@@ -18,10 +18,11 @@ namespace KillChord.Runtime.Application.InGame.Battle
         public static AttackResult Calculate(
             AttackDefinition attackDefinition,
             IAttacker attacker,
-            IDefender defender
+            IDefender defender,
+            bool isJustHit = false
             )
         {
-            AttackStepContext stepContext = new AttackStepContext(attackDefinition, attacker, defender);
+            AttackStepContext stepContext = new AttackStepContext(attackDefinition, attacker, defender, isJustHit);
             return attackDefinition.AttackPipeline.Execute(stepContext);
         }
     }

--- a/Assets/Scripts/Runtime/2.Application/InGame/Battle/AttackExecutor.cs
+++ b/Assets/Scripts/Runtime/2.Application/InGame/Battle/AttackExecutor.cs
@@ -20,7 +20,8 @@ namespace KillChord.Runtime.Application.InGame.Battle
         public static AttackResult Execute(
             AttackDefinition attackDefinition,
             IAttacker attacker,
-            IDefender defender
+            IDefender defender,
+            bool isJustHit = false
             )
         {
             if (attackDefinition == null)
@@ -30,8 +31,8 @@ namespace KillChord.Runtime.Application.InGame.Battle
             if (defender == null)
                 throw new ArgumentNullException(nameof(defender));
             // 計算を行い、ダメージを適用する。
-            AttackResult result = AttackCalculator.Calculate(attackDefinition, attacker, defender);
-
+            AttackResult result = AttackCalculator.Calculate(attackDefinition, attacker, defender, isJustHit);
+            
             defender.TakeDamage(result.FinalDamage);
 
             Debug.Log(

--- a/Assets/Scripts/Runtime/2.Application/InGame/Battle/BeatStep.cs
+++ b/Assets/Scripts/Runtime/2.Application/InGame/Battle/BeatStep.cs
@@ -1,5 +1,5 @@
 using KillChord.Runtime.Domain.InGame.Battle;
-
+using KillChord.Runtime.Application.InGame.Music;
 namespace KillChord.Runtime.Application.InGame.Battle
 {
     /// <summary>
@@ -22,6 +22,10 @@ namespace KillChord.Runtime.Application.InGame.Battle
                 return context;
 
             float resultDamage = context.Damage.Value * beatType;
+            if(context.IsJustHit)
+            {
+                resultDamage *= context.AttackDefinition.JustDamageMultiplier;
+            }
             return new AttackStepContext(new Damage(resultDamage), context.CriticalCount, context);
         }
     }

--- a/Assets/Scripts/Runtime/2.Application/InGame/Music/RhythmJustService.cs
+++ b/Assets/Scripts/Runtime/2.Application/InGame/Music/RhythmJustService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace KillChord.Runtime.Application.InGame.Music
@@ -29,7 +30,18 @@ namespace KillChord.Runtime.Application.InGame.Music
 
         public void TriggerJustHit()
         {
+            ChangeJustHit(true);
             OnJustHit?.Invoke();
+        }
+        public bool IsJustHit()
+        {
+            bool wasJustHit = _isJustHit;
+            ChangeJustHit(false); // ジャストヒットの状態は一度確認されたらリセットする
+            return wasJustHit;
+        }
+        public void ChangeJustHit(bool isJustHit)
+        {
+            _isJustHit = isJustHit;
         }
 
         public void Dispose()
@@ -41,6 +53,8 @@ namespace KillChord.Runtime.Application.InGame.Music
             }
         }
 
+
+        private bool _isJustHit;
         private static RhythmJustService _instance;
 
     }

--- a/Assets/Scripts/Runtime/5.InfraStructure/InGame/Battle/AttackDefinitionData.cs
+++ b/Assets/Scripts/Runtime/5.InfraStructure/InGame/Battle/AttackDefinitionData.cs
@@ -21,12 +21,14 @@ namespace KillChord.Runtime.InfraStructure.InGame.Battle
         public bool UseBeatType => _useBeatType;
         /// <summary> ビートタイプを取得する。 </summary>
         public int BeatType => _beatType;
+        /// <summary> ジャストダメージ倍率を取得する。 </summary>
+        public float JustDamageMultiplier => _justDamageMultiplier;
 
         [SerializeField, Tooltip("攻撃名")] private string _attackName;
         [SerializeField, Tooltip("基本ダメージ")] private float _baseDamage;
         [SerializeField, Tooltip("攻撃パラメーターセット")] private AttackParameterSetData _attackParameterSetData;
         [SerializeField, Tooltip("攻撃パイプラインアセット")] private AttackPipelineAsset _attackPipelineAsset;
-
+        [SerializeField, Tooltip("ジャストダメージ倍率")] private float _justDamageMultiplier;
         [SerializeField, Tooltip("ビートタイプを使用するかどうか")] private bool _useBeatType;
         [SerializeField, Tooltip("ビートタイプ")] private int _beatType;
     }

--- a/Assets/Scripts/Runtime/5.InfraStructure/InGame/Battle/AttackDefinitionFactory.cs
+++ b/Assets/Scripts/Runtime/5.InfraStructure/InGame/Battle/AttackDefinitionFactory.cs
@@ -59,7 +59,8 @@ namespace KillChord.Runtime.InfraStructure.InGame.Battle
                 new Damage(data.BaseDamage),
                 attackParameterSet,
                 data.AttackPipelineAsset.Create(),
-                resolvedBeatType
+                resolvedBeatType,
+                data.JustDamageMultiplier
             );
         }
     }


### PR DESCRIPTION
## 概要
- プレイヤー攻撃時のコンテキストに、ジャスト判定を渡して扱えるようにしました
- 攻撃の種類データに、ジャスト時の倍率項目を追加しました
- BeatStep ではグローバルな判定状態を直接参照せず、攻撃コンテキストからジャスト判定を参照してダメージ計算するようにしています

## 変更内容
- `AttackStepContext` にジャスト判定の保持を追加
- `AttackExecutor` / `AttackCalculator` からジャスト判定を受け渡せるように変更
- `AttackDefinition` / `AttackDefinitionData` / `AttackDefinitionFactory` にジャスト倍率項目を追加
- `BeatStep` でジャスト時に `JustDamageMultiplier` を適用するように変更
- `RhythmJustService` はジャスト判定の受け渡し用に利用しています

## 補足
- 上記以外の変更はありません


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ジャストヒット時のダメージ倍率システムを実装しました。リズムに合わせた完璧なタイミングでの攻撃時に、ダメージ倍率を適用できるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HIBIKI5201/SymphonyKillChord/pull/615)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->