### PR TITLE
アラートの通知を別で送るように

### DIFF
--- a/.github/workflows/SinfoniaOperator.yml
+++ b/.github/workflows/SinfoniaOperator.yml
@@ -31,6 +31,7 @@ jobs:
         env: # 使用する環境変数を呼び出す。
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           DISCORD_TASK_CHANNEL_ID: ${{ vars.DISCORD_TASK_CHANNEL_ID }}
+          DISCORD_TASK_ALERT_CHANNEL_ID: ${{ vars.DISCORD_TASK_ALERT_CHANNEL_ID }}
           DISCORD_SPRINT_CHANNEL_ID: ${{ vars.DISCORD_SPRINT_CHANNEL_ID }}
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
           NOTION_TASK_DATABASE_ID: ${{ vars.NOTION_TASK_DATABASE_ID }}

--- a/SinfoniaOperator/SinfoniaOperator/DiscordBotManager.cs
+++ b/SinfoniaOperator/SinfoniaOperator/DiscordBotManager.cs
@@ -62,6 +62,14 @@ namespace SinfoniaStudio.SinfoniaOperator
             Console.WriteLine($"[DiscordBot] タスクチャンネルへの送信を試みます (ChannelID: {channelID})");
             await PushContextAsync(channelID, content);
         }
+        public async Task PushTaskAlertChannelAsync(string content)
+        {
+            await _readyTcs.Task;
+
+            ulong channelID = _env.DiscordTaskAlertChannelID;
+            Console.WriteLine($"[DiscordBot] タスクアラートチャンネルへの送信を試みます (ChannelID: {channelID})");
+            await PushContextAsync(channelID, content);
+        }
 
         /// <summary>
         ///     スプリントチャンネルに文字列をDiscordに出力します。

--- a/SinfoniaOperator/SinfoniaOperator/DiscordEnvironment.cs
+++ b/SinfoniaOperator/SinfoniaOperator/DiscordEnvironment.cs
@@ -8,15 +8,18 @@ namespace SinfoniaStudio.SinfoniaOperator
         public DiscordEnvironment(
             string discordBotTokenKey,
             string discordTaskChannelIDKey,
+            string discordTaskAlertChannelIDKey,
             string discordSprintChannelIDKey)
         {
             EnvironmentVariable discordBotToken = new(discordBotTokenKey);
             EnvironmentVariable discordTaskChannelID = new(discordTaskChannelIDKey);
+            EnvironmentVariable discordTaskAlertChannelID = new(discordTaskAlertChannelIDKey);
             EnvironmentVariable discordSprintChannelID = new(discordSprintChannelIDKey);
 
             if (EnvironmentValidator.Validate([
                 discordBotToken,
                 discordTaskChannelID,
+                discordTaskAlertChannelID,
                 discordSprintChannelID]))
             {
                 throw new ArgumentException("必要な環境変数が見つかりませんでした。");
@@ -24,11 +27,13 @@ namespace SinfoniaStudio.SinfoniaOperator
 
             DiscordBotToken = discordBotToken;
             DiscordTaskChannelID = discordTaskChannelID;
+            DiscordTaskAlertChannelID = discordTaskAlertChannelID;
             DiscordSprintChannelID = discordSprintChannelID;
         }
 
         public readonly string DiscordBotToken;
         public readonly ulong DiscordTaskChannelID;
+        public readonly ulong DiscordTaskAlertChannelID;
         public readonly ulong DiscordSprintChannelID;
 
         public override string ToString()
@@ -36,6 +41,7 @@ namespace SinfoniaStudio.SinfoniaOperator
             StringBuilder sb = new();
             sb.AppendLine($"DiscordBotToken: {(string.IsNullOrEmpty(DiscordBotToken) ? "null or empty" : "set")}, ");
             sb.AppendLine($"DiscordTaskChannelID: {DiscordTaskChannelID}");
+            sb.AppendLine($"DiscordTaskAlertChannelID: {DiscordTaskAlertChannelID}");
             sb.AppendLine($"DiscordSprintChannelID: {DiscordSprintChannelID}");
             return sb.ToString();
         }

--- a/SinfoniaOperator/SinfoniaOperator/NotionTaskListReader.cs
+++ b/SinfoniaOperator/SinfoniaOperator/NotionTaskListReader.cs
@@ -18,7 +18,7 @@ namespace SinfoniaStudio.SinfoniaOperator
         ///     Notionのデータベースにアクセスして、タスクの状況を文字列で返します。
         /// </summary>
         /// <returns></returns>
-        public async Task<string> GetTaskContent()
+        public async Task<TaskContentResult> GetTaskContent()
         {
             try
             {
@@ -31,6 +31,7 @@ namespace SinfoniaStudio.SinfoniaOperator
                 Console.WriteLine($"[TaskReader] 判定基準日 (JST): {today:yyyy/MM/dd}");
 
                 PriorityQueue<StringBuilder, int> outputTaskQueue = new();
+                PriorityQueue<StringBuilder, int> outputTaskAlertQueue = new();
                 int evaluatedCount = 0;
                 int notificationCount = 0;
 
@@ -123,7 +124,7 @@ namespace SinfoniaStudio.SinfoniaOperator
                         StringBuilder endTasksSb = new();
                         AppendTaskSummry(endTasksSb, "🔴納期遅れタスク", pageName, page, startDate, endDate);
                         await AppendPageContentAsync(endTasksSb, page);
-                        outputTaskQueue.Enqueue(endTasksSb, 2);
+                        outputTaskAlertQueue.Enqueue(endTasksSb, 2);
                         Console.WriteLine($"[TaskReader] {pageName}: 納期遅れタスクとして通知リストに追加しました。");
                         continue;
                     }
@@ -134,28 +135,61 @@ namespace SinfoniaStudio.SinfoniaOperator
 
                 Console.WriteLine($"[TaskReader] 評価終了 (評価数: {evaluatedCount}, 通知対象数: {notificationCount})");
 
-                if (outputTaskQueue.Count <= 0)
+                if (outputTaskQueue.Count <= 0 && outputTaskAlertQueue.Count <= 0)
                 {
                     Console.WriteLine("[TaskReader] 今日の開始タスクと納期タスクがありません。通知を送信しません。");
-                    return string.Empty;
+                    return new TaskContentResult(string.Empty, string.Empty, evaluatedCount, notificationCount);
                 }
 
                 // 優先度順にログを並べる。
-                StringBuilder sb =
-                    new($"GitHub Actionsからの定期タスク通知です！ {nowTime:yyyy/MM/dd HH:mm:ss}");
-                while (outputTaskQueue.TryDequeue(out StringBuilder? element, out int priority))
+                string taskLog = string.Empty;
+                if (outputTaskQueue.Count > 0)
                 {
-                    sb.AppendLine(element.ToString());
+                    StringBuilder taskLogSb = new($"[タスク通知] {nowTime:yyyy/MM/dd HH:mm:ss}\n");
+                    while (outputTaskQueue.TryDequeue(out StringBuilder? element, out int priority))
+                    {
+                        taskLogSb.AppendLine(element.ToString());
+                    }
+                    taskLog = taskLogSb.ToString();
+                }
+                string taskAlertLog = string.Empty;
+                if (outputTaskAlertQueue.Count > 0)
+                {
+                    StringBuilder taskAlertSb = new($"GitHub Actionsからの定期アラート通知です！ {nowTime:yyyy/MM/dd HH:mm:ss}");
+                    while (outputTaskAlertQueue.TryDequeue(out StringBuilder? element, out int priority))
+                    {
+                        taskAlertSb.AppendLine(element.ToString());
+                    }
+                    taskAlertLog = taskAlertSb.ToString();
                 }
 
                 Console.WriteLine($"{new string('-', 10)}");
-                return sb.ToString();
+                return new TaskContentResult(taskLog, taskAlertLog, evaluatedCount, notificationCount);
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"[TaskReader] タスク情報の取得中に予期せぬエラーが発生しました: {ex.Message}");
-                return string.Empty;
+                return new TaskContentResult(string.Empty, string.Empty, 0, 0);
             }
+        }
+
+        public readonly struct TaskContentResult
+        {
+            public TaskContentResult(string taskContent, string taskAlertContent, int evaluatedCount, int notificationCount)
+            {
+                TaskContent = taskContent;
+                TaskAlertContent = taskAlertContent;
+                EvaluatedCount = evaluatedCount;
+                NotificationCount = notificationCount;
+            }
+
+            public bool HasTaskContent => !string.IsNullOrWhiteSpace(TaskContent);
+            public bool HasTaskAlertContent => !string.IsNullOrWhiteSpace(TaskAlertContent);
+
+            public readonly string TaskContent;
+            public readonly string TaskAlertContent;
+            public readonly int EvaluatedCount;
+            public readonly int NotificationCount;
         }
 
         private readonly NotionReader _reader;

--- a/SinfoniaOperator/SinfoniaOperator/SinfoniaOperator.cs
+++ b/SinfoniaOperator/SinfoniaOperator/SinfoniaOperator.cs
@@ -83,6 +83,7 @@ namespace SinfoniaStudio.SinfoniaOperator
             }
             else
             {
+                tasks[0] = Task.CompletedTask;
                 Console.WriteLine("[PushTaskList] 送信するタスクがありませんでした。");
             }
 
@@ -92,6 +93,7 @@ namespace SinfoniaStudio.SinfoniaOperator
             }
             else
             {
+                tasks[1] = Task.CompletedTask;
                 Console.WriteLine("[PushTaskList] 送信するタスクアラートがありませんでした。");
             }
 

--- a/SinfoniaOperator/SinfoniaOperator/SinfoniaOperator.cs
+++ b/SinfoniaOperator/SinfoniaOperator/SinfoniaOperator.cs
@@ -7,6 +7,7 @@ namespace SinfoniaStudio.SinfoniaOperator
     {
         private const string DISCORD_BOT_TOKEN = "DISCORD_BOT_TOKEN";
         private const string DISCORD_TASK_CHANNEL_ID = "DISCORD_TASK_CHANNEL_ID";
+        private const string DISCORD_TASK_ALERT_CHANNEL_ID = "DISCORD_TASK_ALERT_CHANNEL_ID";
         private const string DISCORD_SPRINT_CHANNEL_ID = "DISCORD_SPRINT_CHANNEL_ID";
         private const string NOTION_TOKEN = "NOTION_TOKEN";
         private const string NOTION_TASK_DATABASE_ID = "NOTION_TASK_DATABASE_ID";
@@ -26,6 +27,7 @@ namespace SinfoniaStudio.SinfoniaOperator
                 discordEnv = new DiscordEnvironment(
                     DISCORD_BOT_TOKEN,
                     DISCORD_TASK_CHANNEL_ID,
+                    DISCORD_TASK_ALERT_CHANNEL_ID,
                     DISCORD_SPRINT_CHANNEL_ID);
                 notionEnv = new NotionEnvironment(
                     NOTION_TOKEN,
@@ -44,6 +46,7 @@ namespace SinfoniaStudio.SinfoniaOperator
 
             Console.WriteLine("[Main] 環境変数のチェックが完了しました。");
             Console.WriteLine($"[Main] Notion設定 - 日付プロパティ名: '{notionEnv.DatePropertyName}', 名前プロパティ名: '{notionEnv.NamePropertyName}'");
+            Console.WriteLine($"[Main] Discord設定 - タスクチャンネルID: '{discordEnv.DiscordTaskChannelID}', スプリントチャンネルID: '{discordEnv.DiscordSprintChannelID}', タスクアラートチャンネルID: '{discordEnv.DiscordTaskAlertChannelID}'");
 
             // ワーカークラスのインスタンスを生成。
             NotionTaskListReader taskReader = new(notionEnv);
@@ -71,14 +74,28 @@ namespace SinfoniaStudio.SinfoniaOperator
             }
 
             Console.WriteLine("[PushTaskList] タスクリストの取得を開始します...");
-            string taskContent = await reader.GetTaskContent();
-            if (string.IsNullOrEmpty(taskContent))
+            NotionTaskListReader.TaskContentResult taskContent = await reader.GetTaskContent();
+
+            Task[] tasks = new Task[2];
+            if (taskContent.HasTaskContent)
+            {
+                tasks[0] = discordBot.PushTaskChannelAsync(taskContent.TaskContent);
+            }
+            else
             {
                 Console.WriteLine("[PushTaskList] 送信するタスクがありませんでした。");
-                return;
             }
 
-            await discordBot.PushTaskChannelAsync(taskContent);
+            if (taskContent.HasTaskAlertContent)
+            {
+                tasks[1] = discordBot.PushTaskAlertChannelAsync(taskContent.TaskAlertContent);
+            }
+            else
+            {
+                Console.WriteLine("[PushTaskList] 送信するタスクアラートがありませんでした。");
+            }
+
+            await Task.WhenAll(tasks);
         }
 
         private static async Task PushSprint(NotionSprintListReader reader, DiscordBotManager discordBot)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * タスクアラートチャンネルが追加されました。通常のタスク通知と重要なアラート通知を別々のDiscordチャンネルに送信できるようになりました。遅延タスクなどの重要な通知を専用チャンネルで管理できます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HIBIKI5201/SymphonyKillChord/pull/679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->