### PR TITLE
ステージ開始と終了演出を挿入可能なように変更

### DIFF
--- a/Assets/Arts/Animation/Timelines/GameOver.playable
+++ b/Assets/Arts/Animation/Timelines/GameOver.playable
@@ -1,0 +1,437 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-7748223446315980234
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d21dcc2386d650c4597f3633c75a1f98, type: 3}
+  m_Name: Animation Track (1)
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.AnimationTrack
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips: []
+  m_Markers:
+    m_Objects: []
+  m_InfiniteClipPreExtrapolation: 1
+  m_InfiniteClipPostExtrapolation: 1
+  m_InfiniteClipOffsetPosition: {x: 0, y: 0, z: 0}
+  m_InfiniteClipOffsetEulerAngles: {x: 0, y: 0, z: 0}
+  m_InfiniteClipTimeOffset: 0
+  m_InfiniteClipRemoveOffset: 0
+  m_InfiniteClipApplyFootIK: 1
+  mInfiniteClipLoop: 0
+  m_MatchTargetFields: 63
+  m_Position: {x: 0, y: 0, z: 0}
+  m_EulerAngles: {x: 0, y: 0, z: 0}
+  m_AvatarMask: {fileID: 0}
+  m_ApplyAvatarMask: 1
+  m_TrackOffset: 0
+  m_InfiniteClip: {fileID: 5766819369988258907}
+  m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ApplyOffsets: 0
+--- !u!74 &-6766703363527611931
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Recorded
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 1574349066
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.16666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: GameOver
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.TimelineAsset
+  m_Version: 0
+  m_Tracks:
+  - {fileID: 2699657220712495701}
+  - {fileID: -7748223446315980234}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+    m_ScenePreview: 1
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}
+--- !u!114 &2699657220712495701
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d21dcc2386d650c4597f3633c75a1f98, type: 3}
+  m_Name: Animation Track
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.AnimationTrack
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips: []
+  m_Markers:
+    m_Objects: []
+  m_InfiniteClipPreExtrapolation: 1
+  m_InfiniteClipPostExtrapolation: 1
+  m_InfiniteClipOffsetPosition: {x: 0, y: 0, z: 0}
+  m_InfiniteClipOffsetEulerAngles: {x: 0, y: 0, z: 0}
+  m_InfiniteClipTimeOffset: 0
+  m_InfiniteClipRemoveOffset: 0
+  m_InfiniteClipApplyFootIK: 1
+  mInfiniteClipLoop: 0
+  m_MatchTargetFields: 63
+  m_Position: {x: 0, y: 0, z: 0}
+  m_EulerAngles: {x: 0, y: 0, z: 0}
+  m_AvatarMask: {fileID: 0}
+  m_ApplyAvatarMask: 1
+  m_TrackOffset: 0
+  m_InfiniteClip: {fileID: -6766703363527611931}
+  m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ApplyOffsets: 0
+--- !u!74 &5766819369988258907
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Recorded_1
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0.8, y: 0.8, z: 0.8}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.18333334
+        value: {x: 1.5, y: 1.5, z: 1.5}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.5
+        value: {x: 1, y: 1, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.8
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.18333334
+        value: 1.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.8
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.18333334
+        value: 1.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.8
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.18333334
+        value: 1.5
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Arts/Animation/Timelines/GameOver.playable.meta
+++ b/Assets/Arts/Animation/Timelines/GameOver.playable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 252c229c1ace560449da8eedd843f14b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Arts/Animation/Timelines/StageClear.playable
+++ b/Assets/Arts/Animation/Timelines/StageClear.playable
@@ -1,0 +1,437 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-6596586482438994658
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d21dcc2386d650c4597f3633c75a1f98, type: 3}
+  m_Name: Animation Track (1)
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.AnimationTrack
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips: []
+  m_Markers:
+    m_Objects: []
+  m_InfiniteClipPreExtrapolation: 1
+  m_InfiniteClipPostExtrapolation: 1
+  m_InfiniteClipOffsetPosition: {x: 0, y: 0, z: 0}
+  m_InfiniteClipOffsetEulerAngles: {x: 0, y: 0, z: 0}
+  m_InfiniteClipTimeOffset: 0
+  m_InfiniteClipRemoveOffset: 0
+  m_InfiniteClipApplyFootIK: 1
+  mInfiniteClipLoop: 0
+  m_MatchTargetFields: 63
+  m_Position: {x: 0, y: 0, z: 0}
+  m_EulerAngles: {x: 0, y: 0, z: 0}
+  m_AvatarMask: {fileID: 0}
+  m_ApplyAvatarMask: 1
+  m_TrackOffset: 0
+  m_InfiniteClip: {fileID: 841511590481456103}
+  m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ApplyOffsets: 0
+--- !u!114 &-1226373577233523608
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d21dcc2386d650c4597f3633c75a1f98, type: 3}
+  m_Name: Animation Track
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.AnimationTrack
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips: []
+  m_Markers:
+    m_Objects: []
+  m_InfiniteClipPreExtrapolation: 1
+  m_InfiniteClipPostExtrapolation: 1
+  m_InfiniteClipOffsetPosition: {x: 0, y: 0, z: 0}
+  m_InfiniteClipOffsetEulerAngles: {x: 0, y: 0, z: 0}
+  m_InfiniteClipTimeOffset: 0
+  m_InfiniteClipRemoveOffset: 0
+  m_InfiniteClipApplyFootIK: 1
+  mInfiniteClipLoop: 0
+  m_MatchTargetFields: 63
+  m_Position: {x: 0, y: 0, z: 0}
+  m_EulerAngles: {x: 0, y: 0, z: 0}
+  m_AvatarMask: {fileID: 0}
+  m_ApplyAvatarMask: 1
+  m_TrackOffset: 0
+  m_InfiniteClip: {fileID: 3674417274536467622}
+  m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ApplyOffsets: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: StageClear
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.TimelineAsset
+  m_Version: 0
+  m_Tracks:
+  - {fileID: -1226373577233523608}
+  - {fileID: -6596586482438994658}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+    m_ScenePreview: 1
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}
+--- !u!74 &841511590481456103
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Recorded_1
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0.8, y: 0.8, z: 0.8}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.16666667
+        value: {x: 1.3, y: 1.3, z: 1.3}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 0.5
+        value: {x: 1, y: 1, z: 1}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 3
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.5
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.8
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 1.3
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.x
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.8
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 1.3
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.y
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.8
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 1.3
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalScale.z
+    path: 
+    classID: 224
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []
+--- !u!74 &3674417274536467622
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Recorded
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 1574349066
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.16666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.16666667
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Arts/Animation/Timelines/StageClear.playable.meta
+++ b/Assets/Arts/Animation/Timelines/StageClear.playable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e78bc196393ddca49a8dbebd764a45db
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Arts/Animation/Timelines/StageStart.playable
+++ b/Assets/Arts/Animation/Timelines/StageStart.playable
@@ -93,7 +93,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.48333332
+        time: 2.4833333
         value: 1
         inSlope: 0
         outSlope: 0
@@ -102,7 +102,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1.3333334
+        time: 3.3333333
         value: 1
         inSlope: 0
         outSlope: 0
@@ -111,7 +111,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1.6666666
+        time: 3.6666667
         value: 0
         inSlope: 0
         outSlope: 0
@@ -150,7 +150,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1.6666666
+    m_StopTime: 3.6666667
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -180,7 +180,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 0.48333332
+        time: 2.4833333
         value: 1
         inSlope: 0
         outSlope: 0
@@ -189,7 +189,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1.3333334
+        time: 3.3333333
         value: 1
         inSlope: 0
         outSlope: 0
@@ -198,7 +198,7 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
-        time: 1.6666666
+        time: 3.6666667
         value: 0
         inSlope: 0
         outSlope: 0

--- a/Assets/Arts/Animation/Timelines/StageStart.playable
+++ b/Assets/Arts/Animation/Timelines/StageStart.playable
@@ -1,0 +1,220 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5894260030613724543
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d21dcc2386d650c4597f3633c75a1f98, type: 3}
+  m_Name: Animation Track
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.AnimationTrack
+  m_Version: 3
+  m_AnimClip: {fileID: 0}
+  m_Locked: 0
+  m_Muted: 0
+  m_CustomPlayableFullTypename: 
+  m_Curves: {fileID: 0}
+  m_Parent: {fileID: 11400000}
+  m_Children: []
+  m_Clips: []
+  m_Markers:
+    m_Objects: []
+  m_InfiniteClipPreExtrapolation: 1
+  m_InfiniteClipPostExtrapolation: 1
+  m_InfiniteClipOffsetPosition: {x: 0, y: 0, z: 0}
+  m_InfiniteClipOffsetEulerAngles: {x: 0, y: 0, z: 0}
+  m_InfiniteClipTimeOffset: 0
+  m_InfiniteClipRemoveOffset: 0
+  m_InfiniteClipApplyFootIK: 1
+  mInfiniteClipLoop: 0
+  m_MatchTargetFields: 63
+  m_Position: {x: 0, y: 0, z: 0}
+  m_EulerAngles: {x: 0, y: 0, z: 0}
+  m_AvatarMask: {fileID: 0}
+  m_ApplyAvatarMask: 1
+  m_TrackOffset: 0
+  m_InfiniteClip: {fileID: 216734562121014452}
+  m_OpenClipOffsetRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_Rotation: {x: 0, y: 0, z: 0, w: 1}
+  m_ApplyOffsets: 0
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bfda56da833e2384a9677cd3c976a436, type: 3}
+  m_Name: StageStart
+  m_EditorClassIdentifier: Unity.Timeline::UnityEngine.Timeline.TimelineAsset
+  m_Version: 0
+  m_Tracks:
+  - {fileID: -5894260030613724543}
+  m_FixedDuration: 0
+  m_EditorSettings:
+    m_Framerate: 60
+    m_ScenePreview: 1
+  m_DurationMode: 0
+  m_MarkerTrack: {fileID: 0}
+--- !u!74 &216734562121014452
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Recorded
+  serializedVersion: 7
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.48333332
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.3333334
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.6666666
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 1574349066
+      script: {fileID: 0}
+      typeID: 225
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.6666666
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.48333332
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.3333334
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 1.6666666
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_Alpha
+    path: 
+    classID: 225
+    script: {fileID: 0}
+    flags: 0
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Arts/Animation/Timelines/StageStart.playable.meta
+++ b/Assets/Arts/Animation/Timelines/StageStart.playable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d97dc1735b27c8d42a8789466763473d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Level/Scenes/Master/InGame.unity
+++ b/Assets/Level/Scenes/Master/InGame.unity
@@ -163,6 +163,306 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &150927063
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 150927064}
+  - component: {fileID: 150927066}
+  - component: {fileID: 150927065}
+  m_Layer: 0
+  m_Name: BackGround
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &150927064
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 150927063}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 191554233}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &150927065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 150927063}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &150927066
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 150927063}
+  m_CullTransparentMesh: 1
+--- !u!1 &191554232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 191554233}
+  - component: {fileID: 191554236}
+  - component: {fileID: 191554235}
+  - component: {fileID: 191554234}
+  - component: {fileID: 191554237}
+  - component: {fileID: 191554238}
+  - component: {fileID: 191554239}
+  - component: {fileID: 191554240}
+  m_Layer: 0
+  m_Name: StageSequenceCanvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &191554233
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191554232}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 150927064}
+  - {fileID: 395575198}
+  m_Father: {fileID: 1435826634}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &191554234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191554232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GraphicRaycaster
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &191554235
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191554232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 1
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &191554236
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191554232}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!225 &191554237
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191554232}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
+--- !u!114 &191554238
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191554232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91ddf2a26f9c9ba4da832771331fcee4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: KillChord.View::KillChord.Runtime.View.InGame.Sequence.StageResultUIView
+  _canvasGroup: {fileID: 191554237}
+  _messageText: {fileID: 395575199}
+  _stageStartMessage: Mission Start!
+  _clearMessage: Stage Clear!
+  _gameOverMessage: Game Over!
+--- !u!114 &191554239
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191554232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd363b3112879b84a9cc5cbed830f2d4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: KillChord.View::KillChord.Runtime.View.InGame.Sequence.StageSequenceView
+  _stageStartDirector: {fileID: 1133198437}
+  _stageClearDirector: {fileID: 1049257178}
+  _gameOverDirector: {fileID: 1146523376}
+--- !u!95 &191554240
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191554232}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!1 &255723354
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 255723356}
+  - component: {fileID: 255723355}
+  m_Layer: 0
+  m_Name: InGamePlayDirector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &255723355
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 255723354}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 24a950994675c7447bfa2f5d10029458, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: KillChord.Composition::KillChord.Runtime.Composition.InGame.Sequence.InGamePlayDirector
+  _gamePlayControllableObjects:
+  - {fileID: 446653466}
+  - {fileID: 1136649845}
+  - {fileID: 1772279158}
+  - {fileID: 1249666141}
+  - {fileID: 866643815}
+  - {fileID: 887821557}
+--- !u!4 &255723356
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 255723354}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 446653467}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &358335847
 GameObject:
   m_ObjectHideFlags: 0
@@ -242,6 +542,166 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &395575197
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 395575198}
+  - component: {fileID: 395575200}
+  - component: {fileID: 395575199}
+  - component: {fileID: 395575201}
+  m_Layer: 0
+  m_Name: MessageText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &395575198
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395575197}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 191554233}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1000, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &395575199
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395575197}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: MissionStart!!
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 80
+  m_fontSizeBase: 80
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &395575200
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395575197}
+  m_CullTransparentMesh: 1
+--- !u!95 &395575201
+Animator:
+  serializedVersion: 7
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 395575197}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 0}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
 --- !u!1 &419177558
 GameObject:
   m_ObjectHideFlags: 0
@@ -342,12 +802,15 @@ MonoBehaviour:
   _enemyInfantryTestSpawner: {fileID: 1136649845}
   _enemyArtilleryTestSpawner: {fileID: 1772279158}
   _inGameMissionInitializer: {fileID: 866643817}
-  _mobileInput: {fileID: 0}
+  _mobileInput: {fileID: 1660467405200683237}
   _rhythmGuideInitializer: {fileID: 678096161}
   _backgroundSceneName: Stage_01
   _enemyPools: {fileID: 1599172285}
   _enemyInitializer: {fileID: 1599172287}
   _enemySpawnPositionSearcher: {fileID: 1443016744}
+  _stageSequenceView: {fileID: 191554239}
+  _stageResultUIView: {fileID: 191554238}
+  _inGamePlayDirector: {fileID: 255723355}
 --- !u!4 &438459090
 Transform:
   m_ObjectHideFlags: 0
@@ -377,6 +840,50 @@ MonoBehaviour:
   m_EditorClassIdentifier: KillChord.Composition::KillChord.Runtime.Composition.SkillInitializer
   _skillRepository: {fileID: 11400000, guid: 0837f0ef1d99b414fa1c14e525be2eb4, type: 2}
   _skillVisuals: []
+--- !u!1 &446653465
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 446653467}
+  - component: {fileID: 446653466}
+  m_Layer: 0
+  m_Name: input
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &446653466
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 446653465}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59490565deb1bfd4894ea9dd1eaa5ce1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: KillChord.Composition::KillChord.Runtime.Composition.InGame.Sequence.InputGamePlayControllable
+--- !u!4 &446653467
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 446653465}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 255723356}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &456552175
 GameObject:
   m_ObjectHideFlags: 0
@@ -757,11 +1264,115 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+--- !u!1 &1049257176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1049257177}
+  - component: {fileID: 1049257178}
+  m_Layer: 0
+  m_Name: PlayableDirector_StageClear
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1049257177
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1049257176}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1435826634}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!320 &1049257178
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1049257176}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: e78bc196393ddca49a8dbebd764a45db, type: 2}
+  m_InitialState: 0
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 2
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: -1226373577233523608, guid: e78bc196393ddca49a8dbebd764a45db, type: 2}
+    value: {fileID: 191554240}
+  - key: {fileID: -6596586482438994658, guid: e78bc196393ddca49a8dbebd764a45db, type: 2}
+    value: {fileID: 395575201}
+  m_ExposedReferences:
+    m_References: []
 --- !u!224 &1122440035 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5105896127615380062, guid: 9ca6e05b5f008424f9c1a510f77026b0, type: 3}
   m_PrefabInstance: {fileID: 887821556}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1133198435
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1133198436}
+  - component: {fileID: 1133198437}
+  m_Layer: 0
+  m_Name: PlayableDirector_StageStart
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1133198436
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133198435}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1435826634}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!320 &1133198437
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1133198435}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: d97dc1735b27c8d42a8789466763473d, type: 2}
+  m_InitialState: 0
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 2
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: -5894260030613724543, guid: d97dc1735b27c8d42a8789466763473d, type: 2}
+    value: {fileID: 191554240}
+  m_ExposedReferences:
+    m_References: []
 --- !u!1 &1136649842
 GameObject:
   m_ObjectHideFlags: 0
@@ -813,6 +1424,59 @@ MonoBehaviour:
   _spawnBatchCount: 2
   _maxSpawnCount: 3
   _spawnPositionSearcher: {fileID: 1443016744}
+--- !u!1 &1146523374
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1146523375}
+  - component: {fileID: 1146523376}
+  m_Layer: 0
+  m_Name: PlayableDirector_GameOver
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1146523375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1146523374}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1435826634}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!320 &1146523376
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1146523374}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: 252c229c1ace560449da8eedd843f14b, type: 2}
+  m_InitialState: 0
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 2
+  m_InitialTime: 0
+  m_SceneBindings:
+  - key: {fileID: 2699657220712495701, guid: 252c229c1ace560449da8eedd843f14b, type: 2}
+    value: {fileID: 191554240}
+  - key: {fileID: -7748223446315980234, guid: 252c229c1ace560449da8eedd843f14b, type: 2}
+    value: {fileID: 395575201}
+  m_ExposedReferences:
+    m_References: []
 --- !u!1 &1249666140
 GameObject:
   m_ObjectHideFlags: 0
@@ -872,6 +1536,41 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1435826633
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1435826634}
+  m_Layer: 0
+  m_Name: StageSequenceRoot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1435826634
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1435826633}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1133198436}
+  - {fileID: 1049257177}
+  - {fileID: 1146523375}
+  - {fileID: 191554233}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1443016743
@@ -1320,6 +2019,17 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d2a8e10c660fdb24eb95e8a3849bc98f, type: 3}
+--- !u!114 &1660467405200683237 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8485266662915012930, guid: d2a8e10c660fdb24eb95e8a3849bc98f, type: 3}
+  m_PrefabInstance: {fileID: 1660467405200683236}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00dafdea7818d9c439d79a7e9a48a481, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: KillChord.View::KillChord.Runtime.View.MobileInput
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1342,3 +2052,5 @@ SceneRoots:
   - {fileID: 1599172286}
   - {fileID: 1443016745}
   - {fileID: 358335850}
+  - {fileID: 255723356}
+  - {fileID: 1435826634}

--- a/Assets/Scripts/Runtime/2.Application/InGame/Mission/MissionRuntimeService.cs
+++ b/Assets/Scripts/Runtime/2.Application/InGame/Mission/MissionRuntimeService.cs
@@ -1,4 +1,5 @@
 using KillChord.Runtime.Domain.InGame.Mission;
+using System;
 
 namespace KillChord.Runtime.Application.InGame.Mission
 {
@@ -35,6 +36,9 @@ namespace KillChord.Runtime.Application.InGame.Mission
             _missionEvaluationRunner = missionEvaluationRunner;
         }
 
+        /// <summary> ミッション終了イベント。 </summary>
+        public event Action<MissionEndReason> OnMissionFinished;
+
         /// <summary> ミッション定義を取得します。 </summary>
         public MissionDefinition MissionDefinition => _missionDefinition;
         /// <summary> 進行状況を取得します。 </summary>
@@ -52,6 +56,7 @@ namespace KillChord.Runtime.Application.InGame.Mission
             }
             _missionTimeAdvanceUseCase.Execute(_missionProgress, deltaTime);
             _missionRuleRunner.Evaluate(_missionProgress);
+            CheckMissionFinished();
         }
 
         /// <summary>
@@ -66,6 +71,7 @@ namespace KillChord.Runtime.Application.InGame.Mission
             }
             _missionEnemyKilledUseCase.Execute(_missionProgress, enemyMissionKey);
             _missionRuleRunner.Evaluate(_missionProgress);
+            CheckMissionFinished();
         }
 
         /// <summary>
@@ -79,6 +85,7 @@ namespace KillChord.Runtime.Application.InGame.Mission
             }
             _missionPlayerDeadUseCase.Execute(_missionProgress);
             _missionRuleRunner.Evaluate(_missionProgress);
+            CheckMissionFinished();
         }
 
         /// <summary>
@@ -106,5 +113,21 @@ namespace KillChord.Runtime.Application.InGame.Mission
         private readonly MissionRuleRunner _missionRuleRunner;
         /// <summary> 評価実行器。 </summary>
         private readonly MissionEvaluationRunner _missionEvaluationRunner;
+
+        // Tick()などでミッションの終了を検知した際に、
+        // 複数回OnMissionFinishedイベントが発火するのを防止するためのフラグ。
+        private bool _hasFinished = false;
+
+        /// <summary>
+        ///    ミッションが終了しているかどうかをチェックし、終了している場合はイベントを発火させます。
+        /// </summary>
+        private void CheckMissionFinished()
+        {
+            if (_missionProgress.IsFinished && !_hasFinished)
+            {
+                _hasFinished = true;
+                OnMissionFinished?.Invoke(_missionProgress.EndReason);
+            }
+        }
     }
 }

--- a/Assets/Scripts/Runtime/4.View/InGame/Enemy/AIFacade/EnemyBattleAIFacade.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Enemy/AIFacade/EnemyBattleAIFacade.cs
@@ -1,5 +1,6 @@
 using KillChord.Runtime.Adaptor.InGame.Enemy;
 using KillChord.Runtime.Adaptor.InGame.Enemy.EnemyAIFacadeInterface;
+using KillChord.Runtime.View.InGame.Sequence;
 using UnityEngine;
 
 namespace KillChord.Runtime.View.InGame.Enemy.AIFacade
@@ -7,7 +8,7 @@ namespace KillChord.Runtime.View.InGame.Enemy.AIFacade
     /// <summary>
     ///     敵AI用ファサード：戦闘系
     /// </summary>
-    public class EnemyBattleAIFacade : MonoBehaviour, IEnemyBattleAIFacade
+    public class EnemyBattleAIFacade : MonoBehaviour, IEnemyBattleAIFacade, IGameplayControllable
     {
         /// <summary>
         ///     初期化処理。
@@ -16,6 +17,7 @@ namespace KillChord.Runtime.View.InGame.Enemy.AIFacade
         public void Initialize(EnemyAIController aIController)
         {
             _aiController = aIController;
+            _isPlaying = false;
         }
 
         /// <summary>
@@ -23,6 +25,8 @@ namespace KillChord.Runtime.View.InGame.Enemy.AIFacade
         /// </summary>
         public void StartAttack()
         {
+            if (!_isPlaying) return;
+
             _aiController.ReserveAttack();
         }
 
@@ -42,6 +46,24 @@ namespace KillChord.Runtime.View.InGame.Enemy.AIFacade
             _aiController.CancelAttack();
         }
 
+        /// <summary>
+        ///    ゲームプレイの開始処理を行います。
+        /// </summary>
+        public void StartGameplay()
+        {
+            _isPlaying = true;
+        }
+
+        /// <summary>
+        ///     ゲームプレイの停止処理を行います。
+        /// </summary>
+        public void StopGameplay()
+        {
+            _isPlaying = false;
+            CancelAttack();
+        }
+
         private EnemyAIController _aiController;
+        private bool _isPlaying;
     }
 }

--- a/Assets/Scripts/Runtime/4.View/InGame/Enemy/EnemyMoveView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Enemy/EnemyMoveView.cs
@@ -1,4 +1,5 @@
 using KillChord.Runtime.Adaptor.InGame.Enemy;
+using KillChord.Runtime.View.InGame.Sequence;
 using KillChord.Runtime.View.InGame.UI;
 using UnityEngine;
 using UnityEngine.AI;
@@ -10,7 +11,7 @@ namespace KillChord.Runtime.View.InGame.Enemy
     ///     敵の移動ロジックはEnemyMoveControllerに委譲される。
     /// </summary>
     [RequireComponent(typeof(NavMeshAgent))]
-    public class EnemyMoveView : MonoBehaviour
+    public class EnemyMoveView : MonoBehaviour, IGameplayControllable
     {
         /// <summary>
         ///     初期化処理。
@@ -22,6 +23,25 @@ namespace KillChord.Runtime.View.InGame.Enemy
         {
             _enemyAIController = enemyAIController;
             _target = target;
+            _isPlaying = false;
+        }
+
+        /// <summary>
+        ///     ゲームプレイの開始処理を行います。
+        /// </summary>
+        public void StartGameplay()
+        {
+            _isPlaying = true;
+        }
+
+        /// <summary>
+        ///    ゲームプレイの停止処理を行います。
+        /// </summary>
+        public void StopGameplay()
+        {
+            _isPlaying = false;
+            StopMoving();
+            StopRotating();
         }
 
         /// <summary>
@@ -38,7 +58,9 @@ namespace KillChord.Runtime.View.InGame.Enemy
         /// </summary>
         public void MoveToAttack()
         {
+            if (!_isPlaying) return;
             if (!_navMeshAgent.isOnNavMesh || _target == null) return;
+
             EnemyMoveInstruction intruction = _enemyAIController.GetMoveInstruction(transform.position, _target.position);
             if (intruction.ShouldMove)
             {
@@ -54,16 +76,24 @@ namespace KillChord.Runtime.View.InGame.Enemy
         /// </summary>
         public void StopMoving()
         {
+            if (!CanUseNavMeshAgent())
+            {
+                return;
+            }
+
             _navMeshAgent.isStopped = true;
         }
 
         public void StopRotating()
         {
+            if (_navMeshAgent == null || _navMeshAgent.enabled) return;
+
             _navMeshAgent.updateRotation = false;
         }
         private NavMeshAgent _navMeshAgent;
         private Transform _target;
         private EnemyAIController _enemyAIController;
+        private bool _isPlaying;
 
         private void Awake()
         {
@@ -103,10 +133,22 @@ namespace KillChord.Runtime.View.InGame.Enemy
             }
         }
         /// <summary>
+        ///     NavMeshAgentが使用可能かどうかを確認する。
+        /// </summary>
+        /// <returns> 使用可能であればtrue、そうでなければfalse。 </returns>
+        private bool CanUseNavMeshAgent()
+        {
+            return _navMeshAgent != null
+                && _navMeshAgent.enabled
+                && _navMeshAgent.isOnNavMesh;
+        }
+        /// <summary>
         ///     攻撃を予約するエフェクトを再生する。
         /// </summary>
         private void PlayEffectReserved()
         {
+            if (!_isPlaying) return;
+
             ParticleController.Instance.PlayParticleReserve(transform.position);
         }
         /// <summary>
@@ -114,6 +156,8 @@ namespace KillChord.Runtime.View.InGame.Enemy
         /// </summary>
         private void PlayEffectHit()
         {
+            if (!_isPlaying) return;
+
             ParticleController.Instance.PlayParticle(transform.position);
             MoveToAttack();
         }
@@ -130,7 +174,7 @@ namespace KillChord.Runtime.View.InGame.Enemy
         /// </summary>
         private void On2BeatBefore()
         {
-            
+
         }
     }
 }

--- a/Assets/Scripts/Runtime/4.View/InGame/Enemy/EnemyMoveView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Enemy/EnemyMoveView.cs
@@ -86,7 +86,7 @@ namespace KillChord.Runtime.View.InGame.Enemy
 
         public void StopRotating()
         {
-            if (_navMeshAgent == null || _navMeshAgent.enabled) return;
+            if (_navMeshAgent == null || !_navMeshAgent.enabled) return;
 
             _navMeshAgent.updateRotation = false;
         }

--- a/Assets/Scripts/Runtime/4.View/InGame/Mission/MissionLoopView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Mission/MissionLoopView.cs
@@ -1,4 +1,5 @@
 using KillChord.Runtime.Adaptor.InGame.Mission;
+using KillChord.Runtime.View.InGame.Sequence;
 using UnityEngine;
 
 namespace KillChord.Runtime.View.InGame.Mission
@@ -6,7 +7,7 @@ namespace KillChord.Runtime.View.InGame.Mission
     /// <summary>
     ///     ミッションの定期更新を処理するビュークラス。
     /// </summary>
-    public class MissionLoopView : MonoBehaviour
+    public class MissionLoopView : MonoBehaviour, IGameplayControllable
     {
         /// <summary>
         ///     初期化処理を行います。
@@ -17,15 +18,27 @@ namespace KillChord.Runtime.View.InGame.Mission
             _missionEventController = missionEventController;
         }
 
+        /// <summary> ゲームプレイを開始します。 </summary>
+        public void StartGameplay() => _isPlaying = true;
+
+        /// <summary> ゲームプレイを停止します。 </summary>
+        public void StopGameplay() => _isPlaying = false;
+
         /// <summary>
         ///     UnityのUpdateメソッド。
         /// </summary>
         private void Update()
         {
+            if (!_isPlaying)
+            {
+                return;
+            }
+
             _missionEventController?.Tick(Time.deltaTime);
         }
 
         /// <summary> ミッションイベントコントローラー。 </summary>
         private MissionEventController _missionEventController;
+        private bool _isPlaying;
     }
 }

--- a/Assets/Scripts/Runtime/4.View/InGame/Music/RhythmGuideUpdateView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Music/RhythmGuideUpdateView.cs
@@ -1,4 +1,5 @@
 using KillChord.Runtime.Adaptor.InGame.Music;
+using KillChord.Runtime.View.InGame.Sequence;
 using UnityEngine;
 
 namespace KillChord.Runtime.View.InGame.Music
@@ -6,7 +7,7 @@ namespace KillChord.Runtime.View.InGame.Music
     /// <summary>
     ///     リズムガイドの更新を毎フレーム行うViewクラス。
     /// </summary>
-    public class RhythmGuideUpdateView : MonoBehaviour
+    public class RhythmGuideUpdateView : MonoBehaviour, IGameplayControllable
     {
         /// <summary>
         ///     更新用Viewを初期化する。
@@ -20,16 +21,36 @@ namespace KillChord.Runtime.View.InGame.Music
             _presenter = presenter;
             _viewModel = viewModel;
         }
+        /// <summary>
+        ///    ゲームプレイの開始処理を行います。
+        /// </summary>
+        public void StartGameplay()
+        {
+            _isPlaying = true;
+        }
+        /// <summary>
+        ///    ゲームプレイの停止処理を行います。
+        /// </summary>
+        public void StopGameplay()
+        {
+            _isPlaying = false;
+        }
 
         private RhythmGuideViewModel _viewModel;
         private RhythmGuideView _view;
         private RhythmGuidePresenter _presenter;
+        private bool _isPlaying;
 
         /// <summary>
         ///     毎フレームの更新処理。プレゼンターからデータを受け取り、ビューモデルとViewを更新する。
         /// </summary>
         private void Update()
         {
+            if (!_isPlaying)
+            {
+                return;
+            }
+
             if (_presenter == null || _viewModel == null || _view == null)
             {
                 return;

--- a/Assets/Scripts/Runtime/4.View/InGame/Player/PlayerView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Player/PlayerView.cs
@@ -4,6 +4,7 @@ using KillChord.Runtime.Adaptor.InGame.Battle;
 using KillChord.Runtime.Adaptor.InGame.Player;
 using KillChord.Runtime.Adaptor.Persistent.Input;
 using KillChord.Runtime.Utility.Collections;
+using KillChord.Runtime.View.InGame.Sequence;
 using KillChord.Runtime.View.Persistent.Input;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,14 +17,15 @@ namespace KillChord.Runtime.View.InGame.Player
     ///     プレイヤー入力を受け取り、移動と攻撃を更新するViewクラス。
     /// </summary>
     [DefaultExecutionOrder(ExecutionOrderConst.MOVEMENT)]
-    public sealed class PlayerView : MonoBehaviour, IDamageable
+    public sealed class PlayerView : MonoBehaviour, IDamageable, IGameplayControllable
     {
         [SerializeField] private string _blendName;
         [SerializeField] private Animator _animator;
         [SerializeField] private Rigidbody _rb;
         [SerializeField] private CriAtomSource _seSource;
-        
+
         private bool _isInitialized;
+        private bool _isPlaying;
         private bool _isDodge;
         private Vector2 _moveVector;
         private Transform _cacheTransform;
@@ -41,7 +43,7 @@ namespace KillChord.Runtime.View.InGame.Player
         /// <summary> 毎フレーム移動更新を行う。 </summary>
         private void Update()
         {
-            if (!_isInitialized || _controller == null)
+            if (!_isInitialized || !_isPlaying || _controller == null)
             {
                 return;
             }
@@ -81,7 +83,33 @@ namespace KillChord.Runtime.View.InGame.Player
             Debug.Assert(_cameraTransform != null, $"{nameof(_cameraTransform)} is null", this);
 
             _isInitialized = true;
+        }
+
+        /// <summary> ゲームプレイを開始し、入力イベントを購読する。 </summary>
+        public void StartGameplay()
+        {
+            if (!_isInitialized || _playerInputView == null || _isPlaying)
+            {
+                return;
+            }
+
             RegisterActions();
+            _isPlaying = true;
+        }
+
+        /// <summary> ゲームプレイを停止し、入力イベントの購読を解除する。 </summary>
+        public void StopGameplay()
+        {
+            if (!_isPlaying)
+            {
+                return;
+            }
+
+            UnRegisterActions();
+
+            _moveVector = Vector3.zero;
+            _isDodge = false;
+            _isPlaying = false;
         }
 
         /// <summary> 入力イベントを購読する。 </summary>

--- a/Assets/Scripts/Runtime/4.View/InGame/Player/PlayerView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Player/PlayerView.cs
@@ -107,9 +107,17 @@ namespace KillChord.Runtime.View.InGame.Player
 
             UnRegisterActions();
 
-            _moveVector = Vector3.zero;
+            _moveVector = Vector2.zero;
             _isDodge = false;
             _isPlaying = false;
+
+            if (_rb != null)
+            {
+                _rb.linearVelocity = Vector3.zero;
+                _rb.angularVelocity = Vector3.zero;
+            }
+
+            _characterAnimationController?.SetVelocity(Vector2.zero);
         }
 
         /// <summary> 入力イベントを購読する。 </summary>

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence.meta
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5ab991a3fbdfce04b9c5b9dbfb5d0bd4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/IGameplayControllable.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/IGameplayControllable.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace KillChord.Runtime.View.InGame.Sequence
+{
+    /// <summary>
+    ///   ゲームプレイの開始と停止の対象に機能の切り替えを行うためのインターフェース。
+    /// </summary>
+    public interface IGameplayControllable
+    {
+        /// <summary>
+        ///   ゲームプレイの開始処理を行います。
+        /// </summary>
+        void StartGameplay();
+
+        /// <summary>
+        ///   ゲームプレイの停止処理を行います。
+        /// </summary>
+        void StopGameplay();
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/IGameplayControllable.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/IGameplayControllable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 96a64549a518ee241aa33dc8a779ed1a

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageResultUIView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageResultUIView.cs
@@ -4,24 +4,57 @@ using UnityEngine;
 namespace KillChord.Runtime.View.InGame.Sequence
 {
     /// <summary>
-    ///    ステージの結果（クリア/ゲームオーバー）を表示するViewクラス。
+    ///     ステージの結果表示やシーケンス用メッセージ表示を行うViewクラス。
     /// </summary>
     public class StageResultUIView : MonoBehaviour
     {
         /// <summary>
-        ///    初期化処理。結果画面を非表示にします。
+        ///     初期化処理。結果画面を非表示にします。
         /// </summary>
-        public void Initialize() => Hide();
+        public void Initialize()
+        {
+            Hide();
+        }
+
+        /// <summary>
+        ///     ステージ開始メッセージを設定します。
+        /// </summary>
+        public void SetStageStartMessage()
+        {
+            SetMessage(_stageStartMessage);
+        }
+
+        /// <summary>
+        ///     ステージクリアメッセージを設定します。
+        /// </summary>
+        public void SetClearMessage()
+        {
+            SetMessage(_clearMessage);
+        }
+
+        /// <summary>
+        ///     ゲームオーバーメッセージを設定します。
+        /// </summary>
+        public void SetGameOverMessage()
+        {
+            SetMessage(_gameOverMessage);
+        }
 
         /// <summary>
         ///     ステージクリアの結果画面を表示します。
         /// </summary>
-        public void ShowClear() => Show(_clearMessage);
+        public void ShowClear()
+        {
+            Show(_clearMessage);
+        }
 
         /// <summary>
         ///     ゲームオーバーの結果画面を表示します。
         /// </summary>
-        public void ShowGameOver() => Show(_gameOverMessage);
+        public void ShowGameOver()
+        {
+            Show(_gameOverMessage);
+        }
 
         /// <summary>
         ///     結果画面を非表示にします。
@@ -38,11 +71,14 @@ namespace KillChord.Runtime.View.InGame.Sequence
             _canvasGroup.blocksRaycasts = false;
         }
 
-        [SerializeField, Tooltip("結果画面全体ののCanvasGroup")]
+        [SerializeField, Tooltip("結果画面全体のCanvasGroup")]
         private CanvasGroup _canvasGroup;
 
         [SerializeField, Tooltip("結果画面に表示するメッセージのText")]
         private TextMeshProUGUI _messageText;
+
+        [SerializeField, Tooltip("ステージ開始時に表示するメッセージ")]
+        private string _stageStartMessage = "Mission Start!";
 
         [SerializeField, Tooltip("ステージクリア時に表示するメッセージ")]
         private string _clearMessage = "Stage Clear!";
@@ -53,18 +89,33 @@ namespace KillChord.Runtime.View.InGame.Sequence
         /// <summary>
         ///     結果画面を表示します。
         /// </summary>
-        /// <param name="message"> 表示するメッセージ。 </param>
+        /// <param name="message">表示するメッセージ。</param>
         private void Show(string message)
         {
-            if (_canvasGroup == null || _messageText == null)
+            SetMessage(message);
+
+            if (_canvasGroup == null)
+            {
+                return;
+            }
+
+            _canvasGroup.alpha = 1f;
+            _canvasGroup.interactable = true;
+            _canvasGroup.blocksRaycasts = true;
+        }
+
+        /// <summary>
+        ///     メッセージのみを変更します。
+        /// </summary>
+        /// <param name="message">表示するメッセージ。</param>
+        private void SetMessage(string message)
+        {
+            if (_messageText == null)
             {
                 return;
             }
 
             _messageText.text = message;
-            _canvasGroup.alpha = 1f;
-            _canvasGroup.interactable = true;
-            _canvasGroup.blocksRaycasts = true;
         }
     }
 }

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageResultUIView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageResultUIView.cs
@@ -1,0 +1,70 @@
+using TMPro;
+using UnityEngine;
+
+namespace KillChord.Runtime.View.InGame.Sequence
+{
+    /// <summary>
+    ///    ステージの結果（クリア/ゲームオーバー）を表示するViewクラス。
+    /// </summary>
+    public class StageResultUIView : MonoBehaviour
+    {
+        /// <summary>
+        ///    初期化処理。結果画面を非表示にします。
+        /// </summary>
+        public void Initialize() => Hide();
+
+        /// <summary>
+        ///     ステージクリアの結果画面を表示します。
+        /// </summary>
+        public void ShowClear() => Show(_clearMessage);
+
+        /// <summary>
+        ///     ゲームオーバーの結果画面を表示します。
+        /// </summary>
+        public void ShowGameOver() => Show(_gameOverMessage);
+
+        /// <summary>
+        ///     結果画面を非表示にします。
+        /// </summary>
+        public void Hide()
+        {
+            if (_canvasGroup == null)
+            {
+                return;
+            }
+
+            _canvasGroup.alpha = 0f;
+            _canvasGroup.interactable = false;
+            _canvasGroup.blocksRaycasts = false;
+        }
+
+        [SerializeField, Tooltip("結果画面全体ののCanvasGroup")]
+        private CanvasGroup _canvasGroup;
+
+        [SerializeField, Tooltip("結果画面に表示するメッセージのText")]
+        private TextMeshProUGUI _messageText;
+
+        [SerializeField, Tooltip("ステージクリア時に表示するメッセージ")]
+        private string _clearMessage = "Stage Clear!";
+
+        [SerializeField, Tooltip("ゲームオーバー時に表示するメッセージ")]
+        private string _gameOverMessage = "Game Over!";
+
+        /// <summary>
+        ///     結果画面を表示します。
+        /// </summary>
+        /// <param name="message"> 表示するメッセージ。 </param>
+        private void Show(string message)
+        {
+            if (_canvasGroup == null || _messageText == null)
+            {
+                return;
+            }
+
+            _messageText.text = message;
+            _canvasGroup.alpha = 1f;
+            _canvasGroup.interactable = true;
+            _canvasGroup.blocksRaycasts = true;
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageResultUIView.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageResultUIView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 91ddf2a26f9c9ba4da832771331fcee4

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
@@ -51,7 +51,6 @@ namespace KillChord.Runtime.View.InGame.Sequence
             {
                 // キャンセルされた場合は演出も停止。
                 director.Stop();
-
             }
         }
 

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
@@ -72,7 +72,6 @@ namespace KillChord.Runtime.View.InGame.Sequence
             {
                 // キャンセルされた場合は演出も停止。
                 director.Stop();
-                throw;
             }
         }
 

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
@@ -11,21 +11,42 @@ namespace KillChord.Runtime.View.InGame.Sequence
     /// </summary>
     public class StageSequenceView : MonoBehaviour
     {
+        /// <summary>
+        ///    ステージ開始演出を再生します。
+        /// </summary>
+        /// <param name="cancellationToken"> キャンセル用のトークン。 </param>
+        /// <returns> 演出の再生が完了するまで待機するAwaitable。 </returns>
         public async Awaitable PlayStageStartAsync(CancellationToken cancellationToken)
         {
             await PlayAsync(_stageStartDirector, cancellationToken);
         }
 
+        /// <summary>
+        ///     ステージクリア演出を再生します。
+        /// </summary>
+        /// <param name="cancellationToken"> キャンセル用のトークン。 </param>
+        /// <returns> 演出の再生が完了するまで待機するAwaitable。 </returns>
         public async Awaitable PlayStageClearAsync(CancellationToken cancellationToken)
         {
             await PlayAsync(_stageClearDirector, cancellationToken);
         }
 
+        /// <summary>
+        ///     ゲームオーバー演出を再生します。
+        /// </summary>
+        /// <param name="cancellationToken"> キャンセル用のトークン。 </param>
+        /// <returns> 演出の再生が完了するまで待機するAwaitable。 </returns>
         public async Awaitable PlayGameOverAsync(CancellationToken cancellationToken)
         {
             await PlayAsync(_gameOverDirector, cancellationToken);
         }
 
+        /// <summary>
+        ///     指定されたPlayableDirectorの演出を再生し、完了するまで待機します。
+        /// </summary>
+        /// <param name="director"> 再生するPlayableDirector。 </param>
+        /// <param name="cancellationToken"> キャンセル用のトークン。 </param>
+        /// <returns> 演出の再生が完了するまで待機するAwaitable。 </returns>
         private static async Awaitable PlayAsync(
             PlayableDirector director,
             CancellationToken cancellationToken)

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
@@ -72,6 +72,7 @@ namespace KillChord.Runtime.View.InGame.Sequence
             {
                 // キャンセルされた場合は演出も停止。
                 director.Stop();
+                throw;
             }
         }
 

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Threading;
+using UnityEngine;
+using UnityEngine.Playables;
+
+namespace KillChord.Runtime.View.InGame.Sequence
+{
+    /// <summary>
+    ///     ステージの開始と終了演出を再生するViewクラス。
+    ///     現在はTimeline専用のクラス。
+    /// </summary>
+    public class StageSequenceView : MonoBehaviour
+    {
+        public async Awaitable PlayStageStartAsync(CancellationToken cancellationToken)
+        {
+            await PlayAsync(_stageStartDirector, cancellationToken);
+        }
+
+        public async Awaitable PlayStageClearAsync(CancellationToken cancellationToken)
+        {
+            await PlayAsync(_stageClearDirector, cancellationToken);
+        }
+
+        public async Awaitable PlayGameOverAsync(CancellationToken cancellationToken)
+        {
+            await PlayAsync(_gameOverDirector, cancellationToken);
+        }
+
+        private static async Awaitable PlayAsync(
+            PlayableDirector director,
+            CancellationToken cancellationToken)
+        {
+            if (director == null)
+            {
+                Debug.LogWarning("PlayableDirectorが設定されていません。");
+                return;
+            }
+
+            director.time = 0;
+            director.Play();
+
+            try
+            {
+                // 再生が終了するまで待機。
+                while (director.state == PlayState.Playing)
+                {
+                    await Awaitable.NextFrameAsync(cancellationToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // キャンセルされた場合は演出も停止。
+                director.Stop();
+
+            }
+        }
+
+        [SerializeField, Tooltip("ステージ開始演出のPlayableDirector")]
+        private PlayableDirector _stageStartDirector;
+
+        [SerializeField, Tooltip("ステージクリア演出のPlayableDirector")]
+        private PlayableDirector _stageClearDirector;
+
+        [SerializeField, Tooltip("ゲームオーバー時のPlayableDirector")]
+        private PlayableDirector _gameOverDirector;
+    }
+}

--- a/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs.meta
+++ b/Assets/Scripts/Runtime/4.View/InGame/Sequence/StageSequenceView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd363b3112879b84a9cc5cbed830f2d4

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Bootstrap/IngameComposition.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Bootstrap/IngameComposition.cs
@@ -9,6 +9,7 @@ using KillChord.Runtime.Composition.InGame.Sequence;
 using KillChord.Runtime.Composition.Persistent.Input;
 using KillChord.Runtime.Domain.InGame.Mission;
 using KillChord.Runtime.View.InGame.Enemy;
+using KillChord.Runtime.View.InGame.Player;
 using KillChord.Runtime.View.InGame.Scene;
 using KillChord.Runtime.View.InGame.Sequence;
 using KillChord.Runtime.View.Persistent.Input;
@@ -137,6 +138,16 @@ namespace KillChord.Runtime.Composition.InGame.Bootstrap
 
             _playerInitializer.Initialize(targetManager, targetEntityRegistry, inputC);
 
+            PlayerView playerView = FindFirstObjectByType<PlayerView>();
+
+            if (playerView == null)
+            {
+                Debug.LogError("[IngameComposition] PlayerView が見つかりません。");
+                return false;
+            }
+
+            _inGamePlayDirector.AddGamePlayControllable(playerView);
+
             // ステージに事前配置されている敵の情報
             AssignedEnemyManager assignedEnemyManager = FindFirstObjectByType<AssignedEnemyManager>();
             if (assignedEnemyManager == null)
@@ -262,6 +273,11 @@ namespace KillChord.Runtime.Composition.InGame.Bootstrap
             if (_inGamePlayDirector == null)
             {
                 Debug.LogError("[IngameComposition] InGamePlayDirectorの参照が未設定です。", this);
+                return false;
+            }
+            if(_stageResultUIView == null)
+            {
+                Debug.LogError("[IngameComposition] StageResultUIViewの参照が未設定です。", this);
                 return false;
             }
 

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Bootstrap/IngameComposition.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Bootstrap/IngameComposition.cs
@@ -1,12 +1,16 @@
 using KillChord.Runtime.Application.InGame.Camera.Target;
+using KillChord.Runtime.Application.InGame.Mission;
 using KillChord.Runtime.Composition.InGame.Camera;
 using KillChord.Runtime.Composition.InGame.Enemy;
 using KillChord.Runtime.Composition.InGame.Mission;
 using KillChord.Runtime.Composition.InGame.Music;
 using KillChord.Runtime.Composition.InGame.Player;
+using KillChord.Runtime.Composition.InGame.Sequence;
 using KillChord.Runtime.Composition.Persistent.Input;
+using KillChord.Runtime.Domain.InGame.Mission;
 using KillChord.Runtime.View.InGame.Enemy;
 using KillChord.Runtime.View.InGame.Scene;
+using KillChord.Runtime.View.InGame.Sequence;
 using KillChord.Runtime.View.Persistent.Input;
 using KillChord.Runtime.View.Persistent.Music;
 using SymphonyFrameWork.Attribute;
@@ -15,6 +19,9 @@ using UnityEngine;
 
 namespace KillChord.Runtime.Composition.InGame.Bootstrap
 {
+    /// <summary>
+    ///    インゲームシーンの全体的な初期化と構成を担当するクラス。
+    /// </summary>
     [DefaultExecutionOrder(-100)]
     public class IngameComposition : MonoBehaviour
     {
@@ -30,71 +37,77 @@ namespace KillChord.Runtime.Composition.InGame.Bootstrap
         [SerializeField] private EnemyPools _enemyPools;
         [SerializeField] private EnemyInitializer _enemyInitializer;
         [SerializeField] private EnemySpawnPositionSearcher _enemySpawnPositionSearcher;
+        [SerializeField] private StageSequenceView _stageSequenceView;
+        [SerializeField] private StageResultUIView _stageResultUIView;
+        [SerializeField] private InGamePlayDirector _inGamePlayDirector;
 
         private PlayerInitializer _playerInitializer;
         private MusicPlayer _musicPlayer;
+        private InGameSequenceDirector _inGameSequenceDirector;
+        private MissionRuntimeService _missionruntimeService;
+        private bool _isEnding = false;
 
         private async void Start()
         {
             await _ingameSceneView.LoadScene(_backgroundSceneName);
 
-            _playerInitializer = ServiceLocator.GetInstance<PlayerInitializer>();
-            if( _playerInitializer == null)
+            if (!await TryInitializeAsync())
             {
-                Debug.LogError("[IngameComposition] PlayerInitializer の取得に失敗しました。");
+                Debug.LogError("[IngameComposition] 初期化に失敗しました。");
                 return;
             }
+
+            _missionruntimeService = ServiceLocator.GetInstance<MissionRuntimeService>();
+            if (_missionruntimeService != null)
+            {
+                _missionruntimeService.OnMissionFinished += HandleMissionFinished;
+
+            }
+
+            await _inGameSequenceDirector.StartAsync(destroyCancellationToken);
+        }
+
+        private void OnDestroy()
+        {
+            if (_missionruntimeService != null)
+            {
+                _missionruntimeService.OnMissionFinished -= HandleMissionFinished;
+            }
+        }
+
+        /// <summary>
+        ///     シーン内の必要なコンポーネントやサービスを非同期に初期化する。
+        /// </summary>
+        /// <returns> 初期化が成功したかどうかを示す値。 </returns>
+        private async Awaitable<bool> TryInitializeAsync()
+        {
+            _playerInitializer = ServiceLocator.GetInstance<PlayerInitializer>();
+
+            if (_playerInitializer == null)
+            {
+                Debug.LogError("[IngameComposition] PlayerInitializer の取得に失敗しました。");
+                return false;
+            }
+
             var stageSceneI = await ServiceLocator.GetInstanceAsync<IStageSceneInstance>();
             Debug.Log(
                 $"stageSceneI {stageSceneI != null}  PlayerT{stageSceneI.PlayerTransform != null} Skill{stageSceneI.SkillInitializer}");
 
-            // 常駐サービスの取得を確実にするため、取得できるまで待機する
-            _musicPlayer = ServiceLocator.GetInstance<MusicPlayer>();
-
-            int retryCount = 0;
-            while (_musicPlayer == null && retryCount < 20)
+            if (!await WaitMusicPlayerAsync())
             {
-                await System.Threading.Tasks.Task.Delay(100);
-                _musicPlayer = ServiceLocator.GetInstance<MusicPlayer>();
-                retryCount++;
-            }
-
-            if (_musicPlayer == null)
-            {
-                Debug.LogError("[IngameComposition] MusicPlayer の取得に失敗しました。常駐シーンがロードされているか確認してください。");
-                return;
+                return false;
             }
 
             UnityEngine.Camera mainCamera = UnityEngine.Camera.main;
             if (mainCamera == null)
             {
                 Debug.LogError("[IngameComposition] MainCamera が見つかりません。");
-                return;
+                return false;
             }
-            if (_enemyPools == null)
+
+            if (!ValidateInitialization())
             {
-                Debug.LogError("[IngameComposition] EnemyPoolsの参照が未設定です。");
-                return;
-            }
-            if (_enemyInitializer == null)
-            {
-                Debug.LogError("[IngameComposition] EnemyInitializerの参照が未設定です。");
-                return;
-            }
-            if (_enemySpawnPositionSearcher == null)
-            {
-                Debug.LogError("[IngameComposition] EnemySpawnPositionSearcherの参照が未設定です。");
-                return;
-            }
-            if (_enemyInfantryTestSpawner == null)
-            {
-                Debug.LogError("[IngameComposition] EnemyInfantryTestSpawnerの参照が未設定です。");
-                return;
-            }
-            if (_enemyArtilleryTestSpawner == null)
-            {
-                Debug.LogError("[IngameComposition] EnemyArtilleryTestSpawnerの参照が未設定です。");
-                return;
+                return false;
             }
 
             TargetManager targetManager = new();
@@ -103,9 +116,17 @@ namespace KillChord.Runtime.Composition.InGame.Bootstrap
             // 初期化順序の実行
             _musicSyncInitializer.Initialize();
             _inGameMissionInitializer.Initialize();
+            _stageResultUIView.Initialize();
 
             var inputC = ServiceLocator.GetInstance<InputComposition>();
-            inputC.GetInputMapController.EnableOnly(InputMapNames.InGame);
+            if (inputC == null)
+            {
+                Debug.LogError("[IngameComposition] InputComposition の取得に失敗しました。", this);
+                return false;
+            }
+
+            inputC.GetInputMapController.EnableOnly(InputMapNames.Common);
+
 #if UNITY_ANDROID
             _camerasystemInitializer.Initialize(targetManager, targetEntityRegistry);
             _mobileInput.Initialize(inputC.GetInputView);
@@ -118,17 +139,19 @@ namespace KillChord.Runtime.Composition.InGame.Bootstrap
 
             // ステージに事前配置されている敵の情報
             AssignedEnemyManager assignedEnemyManager = FindFirstObjectByType<AssignedEnemyManager>();
-            if(assignedEnemyManager == null)
+            if (assignedEnemyManager == null)
             {
                 Debug.LogWarning("[IngameComposition] 敵の事前配置情報がありません。");
             }
             else
             {
-                if (assignedEnemyManager.Infantries == null || assignedEnemyManager.Infantries.Length == 0)
+                if (assignedEnemyManager.Infantries == null
+                    || assignedEnemyManager.Infantries.Length == 0)
                 {
                     Debug.LogWarning("[IngameComposition] 歩兵の事前配置情報がありません。");
                 }
-                if (assignedEnemyManager.Artillery == null || assignedEnemyManager.Artillery.Length == 0)
+                if (assignedEnemyManager.Artillery == null
+                    || assignedEnemyManager.Artillery.Length == 0)
                 {
                     Debug.LogWarning("[IngameComposition] 砲兵の事前配置情報がありません。");
                 }
@@ -142,8 +165,133 @@ namespace KillChord.Runtime.Composition.InGame.Bootstrap
             _enemyInfantryTestSpawner.Initialize(assignedEnemyManager?.Infantries);
             _enemyArtilleryTestSpawner.Initialize(assignedEnemyManager?.Artillery);
 
-            // リズムガイドUI
             _rhythmGuideInitializer.Initialize();
+
+            _inGameSequenceDirector = new InGameSequenceDirector(
+                _stageSequenceView,
+                _stageResultUIView,
+                _inGamePlayDirector
+                );
+            _inGamePlayDirector.StopGameplay();
+
+            return true;
+        }
+
+        /// <summary>
+        ///    MusicPlayer が ServiceLocator から利用可能になるまで待機する。
+        /// </summary>
+        /// <returns> MusicPlayer が利用可能になったかどうかを示す値。 </returns>
+        private async Awaitable<bool> WaitMusicPlayerAsync()
+        {
+            // 常駐サービスの取得を確実にするため、取得できるまで待機する
+            _musicPlayer = ServiceLocator.GetInstance<MusicPlayer>();
+
+            int retryCount = 0;
+            while (_musicPlayer == null && retryCount < 20)
+            {
+                await Awaitable.NextFrameAsync(destroyCancellationToken);
+                _musicPlayer = ServiceLocator.GetInstance<MusicPlayer>();
+                retryCount++;
+            }
+
+            if (_musicPlayer != null)
+            {
+                return true;
+            }
+
+            Debug.LogError("[IngameComposition] MusicPlayer の取得に失敗しました。常駐シーンがロードされているか確認してください。");
+            return false;
+        }
+
+        /// <summary>
+        ///     シーン内の必要なコンポーネントがすべて設定されているかを検証する。
+        /// </summary>
+        /// <returns> 初期化が有効かどうかを示す値。 </returns>
+        private bool ValidateInitialization()
+        {
+            if (_musicSyncInitializer == null)
+            {
+                Debug.LogError("[IngameComposition] MusicSyncInitializerの参照が未設定です。", this);
+                return false;
+            }
+            if (_camerasystemInitializer == null)
+            {
+                Debug.LogError("[IngameComposition] CameraSystemInitializerの参照が未設定です。", this);
+                return false;
+            }
+            if (_ingameSceneView == null)
+            {
+                Debug.LogError("[IngameComposition] IngameSceneViewの参照が未設定です。", this);
+                return false;
+            }
+            if (_enemyPools == null)
+            {
+                Debug.LogError("[IngameComposition] EnemyPoolsの参照が未設定です。", this);
+                return false;
+            }
+            if (_enemyInitializer == null)
+            {
+                Debug.LogError("[IngameComposition] EnemyInitializerの参照が未設定です。", this);
+                return false;
+            }
+            if (_enemySpawnPositionSearcher == null)
+            {
+                Debug.LogError("[IngameComposition] EnemySpawnPositionSearcherの参照が未設定です。", this);
+                return false;
+            }
+            if (_enemyInfantryTestSpawner == null)
+            {
+                Debug.LogError("[IngameComposition] EnemyInfantryTestSpawnerの参照が未設定です。", this);
+                return false;
+            }
+            if (_enemyArtilleryTestSpawner == null)
+            {
+                Debug.LogError("[IngameComposition] EnemyArtilleryTestSpawnerの参照が未設定です。", this);
+                return false;
+            }
+            if (_rhythmGuideInitializer == null)
+            {
+                Debug.LogError("[IngameComposition] RhythmGuideInitializerの参照が未設定です。", this);
+                return false;
+            }
+            if (_stageSequenceView == null)
+            {
+                Debug.LogError("[IngameComposition] StageSequenceViewの参照が未設定です。", this);
+                return false;
+            }
+            if (_inGamePlayDirector == null)
+            {
+                Debug.LogError("[IngameComposition] InGamePlayDirectorの参照が未設定です。", this);
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///     ミッションの終了イベントを処理する。
+        ///     ミッションの終了理由に応じて、クリアシーケンスまたはゲームオーバーシーケンスを開始する。
+        /// </summary>
+        /// <param name="reason">ミッションの終了理由。</param>
+        private async void HandleMissionFinished(MissionEndReason reason)
+        {
+            if (_isEnding)
+            {
+                return;
+            }
+
+            _isEnding = true;
+
+            Debug.Log($"Mission Finished: {reason}");
+            switch (reason)
+            {
+                case MissionEndReason.Clear:
+                    await _inGameSequenceDirector.ClearAsync(destroyCancellationToken);
+                    break;
+                case MissionEndReason.Fail:
+                    await _inGameSequenceDirector.GameOverAsync(destroyCancellationToken);
+                    break;
+            }
         }
     }
 }

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyArtillerySpawner.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyArtillerySpawner.cs
@@ -1,4 +1,5 @@
 using KillChord.Runtime.View.InGame.Enemy;
+using KillChord.Runtime.View.InGame.Sequence;
 using UnityEngine;
 
 namespace KillChord.Runtime.Composition.InGame.Enemy
@@ -6,21 +7,37 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
     /// <summary>
     ///     砲兵のスポナークラス。
     /// </summary>
-    public class EnemyArtillerySpawner : MonoBehaviour
+    public class EnemyArtillerySpawner : MonoBehaviour, IGameplayControllable
     {
         /// <summary>
         ///     初期化処理。
         /// </summary>
         public void Initialize(in Transform[] assignedPositions)
         {
+            _assignedPositions = assignedPositions;
             _spawnPositions = new Vector3[_spawnBatchCount];
             _spawnCount = 0;
             _initialized = true;
-            if (assignedPositions != null)
-            {
-                SpawnAssignedEnemy(assignedPositions);
-            }
+            _timer = 0f;
+            _isPlaying = false;
         }
+
+        public void StartGameplay()
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            if (_assignedPositions != null)
+            {
+                SpawnAssignedEnemy(_assignedPositions);
+            }
+
+            _isPlaying = true;
+        }
+
+        public void StopGameplay() => _isPlaying = false;
 
         /// <summary>
         ///     砲兵インスタンスが回収された時のcallback処理。
@@ -43,10 +60,12 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
         private int _spawnCount;
         private Vector3[] _spawnPositions;
         private bool _initialized = false;
+        private Transform[] _assignedPositions;
+        private bool _isPlaying;
 
         private void Update()
         {
-            if (!_initialized) return;
+            if (!_initialized || !_isPlaying) return;
             if (_spawnCount >= _maxSpawnCount && _maxSpawnCount != -1) return;
 
             _timer += Time.deltaTime;

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyArtillerySpawner.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyArtillerySpawner.cs
@@ -1,5 +1,6 @@
 using KillChord.Runtime.View.InGame.Enemy;
 using KillChord.Runtime.View.InGame.Sequence;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace KillChord.Runtime.Composition.InGame.Enemy
@@ -20,8 +21,13 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
             _initialized = true;
             _timer = 0f;
             _isPlaying = false;
+            _spawnedAssignedEnemies = false;
+            _activeEnemies.Clear();
         }
 
+        /// <summary>
+        ///   ゲームプレイの開始処理を行います。
+        /// </summary>
         public void StartGameplay()
         {
             if (!_initialized)
@@ -29,15 +35,37 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
                 return;
             }
 
-            if (_assignedPositions != null)
+            if (!_spawnedAssignedEnemies && _assignedPositions != null)
             {
                 SpawnAssignedEnemy(_assignedPositions);
+                _spawnedAssignedEnemies = true;
+            }
+
+            // 非アクティブな敵をリストから削除し、残りの敵のゲームプレイを開始する。
+            ReMoveInactiveEnemies();
+
+            for (int i = 0; i < _activeEnemies.Count; i++)
+            {
+                _activeEnemies[i]?.StartGameplay();
             }
 
             _isPlaying = true;
         }
 
-        public void StopGameplay() => _isPlaying = false;
+        /// <summary>
+        ///    ゲームプレイの停止処理を行います。
+        /// </summary>
+        public void StopGameplay()
+        {
+            // 非アクティブな敵をリストから削除し、残りの敵のゲームプレイを停止する。
+            _isPlaying = false;
+            ReMoveInactiveEnemies();
+
+            for (int i = 0; i < _activeEnemies.Count; i++)
+            {
+                _activeEnemies[i]?.StopGameplay();
+            }
+        }
 
         /// <summary>
         ///     砲兵インスタンスが回収された時のcallback処理。
@@ -45,6 +73,8 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
         public void HandleArtilleryDeactivated()
         {
             if (_spawnCount > 0) _spawnCount--;
+
+            ReMoveInactiveEnemies();
         }
 
         [SerializeField] private EnemyPools _enemyPools;
@@ -56,6 +86,8 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
         [SerializeField, Tooltip("敵の生成位置を探索するコンポーネント")]
         private EnemySpawnPositionSearcher _spawnPositionSearcher;
 
+        private readonly List<EnemyLifeCycle> _activeEnemies = new();
+        private bool _spawnedAssignedEnemies;
         private float _timer;
         private int _spawnCount;
         private Vector3[] _spawnPositions;
@@ -87,6 +119,8 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
                 if (_spawnCount >= _maxSpawnCount && _maxSpawnCount != -1) break;
                 EnemyLifeCycle lifeCycle = _enemyPools.GetArtillery();
                 lifeCycle.Activate(_spawnPositions[i], HandleArtilleryDeactivated);
+                lifeCycle.StartGameplay();
+                _activeEnemies.Add(lifeCycle);
                 _spawnCount++;
             }
         }
@@ -106,7 +140,23 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
                 }
                 EnemyLifeCycle lifeCycle = _enemyPools.GetArtillery();
                 lifeCycle.Activate(assignedPositions[i].position, HandleArtilleryDeactivated);
+                lifeCycle.StartGameplay();
+                _activeEnemies.Add(lifeCycle);
                 _spawnCount++;
+            }
+        }
+
+        /// <summary>
+        ///     非アクティブな敵をリストから削除する。
+        /// </summary>
+        private void ReMoveInactiveEnemies()
+        {
+            for (int i = _activeEnemies.Count - 1; i >= 0; i--)
+            {
+                if (_activeEnemies[i] == null || !_activeEnemies[i].gameObject.activeSelf)
+                {
+                    _activeEnemies.RemoveAt(i);
+                }
             }
         }
     }

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyInfantrySpawner.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyInfantrySpawner.cs
@@ -34,7 +34,7 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
                 return;
             }
 
-            if (_assignedPositions != null)
+            if (!_spawnedAssignedEnemies && _assignedPositions != null)
             {
                 SpawnAssignedEnemy(_assignedPositions);
                 _spawnedAssignedEnemies = true;

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyInfantrySpawner.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyInfantrySpawner.cs
@@ -1,5 +1,6 @@
 using KillChord.Runtime.View.InGame.Enemy;
 using KillChord.Runtime.View.InGame.Sequence;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace KillChord.Runtime.Composition.InGame.Enemy
@@ -20,7 +21,12 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
             _initialized = true;
             _timer = 0f;
             _isPlaying = false;
+            _spawnedAssignedEnemies = false;
+            _activeEnemies.Clear();
         }
+        /// <summary>
+        ///   ゲームプレイの開始処理を行います。
+        /// </summary>
         public void StartGameplay()
         {
             if (!_initialized)
@@ -31,12 +37,35 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
             if (_assignedPositions != null)
             {
                 SpawnAssignedEnemy(_assignedPositions);
+                _spawnedAssignedEnemies = true;
+            }
+
+            // 非アクティブな敵をリストから削除し、残りの敵のゲームプレイを開始する。
+            ReMoveInactiveEnemies();
+
+            for (int i = 0; i < _activeEnemies.Count; i++)
+            {
+                _activeEnemies[i]?.StartGameplay();
             }
 
             _isPlaying = true;
         }
 
-        public void StopGameplay() => _isPlaying = false;
+        /// <summary>
+        ///   ゲームプレイの停止処理を行います。
+        /// </summary>
+        public void StopGameplay()
+        {
+            // 非アクティブな敵をリストから削除し、残りの敵のゲームプレイを停止する。
+            _isPlaying = false;
+
+            ReMoveInactiveEnemies();
+
+            for (int i = 0; i < _activeEnemies.Count; i++)
+            {
+                _activeEnemies[i]?.StopGameplay();
+            }
+        }
 
         /// <summary>
         ///     歩兵インスタンスが回収された時のcallback処理。
@@ -44,6 +73,8 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
         public void HandleInfantryDeactivated()
         {
             if (_spawnCount > 0) _spawnCount--;
+
+            ReMoveInactiveEnemies();
         }
 
         [SerializeField] private EnemyPools _enemyPools;
@@ -55,6 +86,8 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
         [SerializeField, Tooltip("敵の生成位置を探索するコンポーネント")]
         private EnemySpawnPositionSearcher _spawnPositionSearcher;
 
+        private readonly List<EnemyLifeCycle> _activeEnemies = new();
+        private bool _spawnedAssignedEnemies;
         private float _timer;
         private int _spawnCount;
         private Vector3[] _spawnPositions;
@@ -87,6 +120,8 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
                 if (_spawnCount >= _maxSpawnCount && _maxSpawnCount != -1) break;
                 EnemyLifeCycle lifeCycle = _enemyPools.GetInfantry();
                 lifeCycle.Activate(_spawnPositions[i], HandleInfantryDeactivated);
+                lifeCycle.StartGameplay();
+                _activeEnemies.Add(lifeCycle);
                 _spawnCount++;
             }
         }
@@ -106,7 +141,23 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
                 }
                 EnemyLifeCycle lifeCycle = _enemyPools.GetInfantry();
                 lifeCycle.Activate(assignedPositions[i].position, HandleInfantryDeactivated);
+                lifeCycle.StartGameplay();
+                _activeEnemies.Add(lifeCycle);
                 _spawnCount++;
+            }
+        }
+
+        /// <summary>
+        ///    非アクティブな敵をリストから削除する。
+        /// </summary>
+        private void ReMoveInactiveEnemies()
+        {
+            for (int i = _activeEnemies.Count - 1; i >= 0; i--)
+            {
+                if (_activeEnemies[i] == null || !_activeEnemies[i].gameObject.activeSelf)
+                {
+                    _activeEnemies.RemoveAt(i);
+                }
             }
         }
     }

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyInfantrySpawner.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyInfantrySpawner.cs
@@ -1,4 +1,5 @@
 using KillChord.Runtime.View.InGame.Enemy;
+using KillChord.Runtime.View.InGame.Sequence;
 using UnityEngine;
 
 namespace KillChord.Runtime.Composition.InGame.Enemy
@@ -6,21 +7,37 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
     /// <summary>
     ///     歩兵のスポナークラス。
     /// </summary>
-    public class EnemyInfantrySpawner : MonoBehaviour
+    public class EnemyInfantrySpawner : MonoBehaviour, IGameplayControllable
     {
         /// <summary>
         ///     初期化処理。
         /// </summary>
         public void Initialize(in Transform[] assignedPositions)
         {
+            _assignedPositions = assignedPositions;
             _spawnPositions = new Vector3[_spawnBatchCount];
             _spawnCount = 0;
             _initialized = true;
-            if(assignedPositions != null)
-            {
-                SpawnAssignedEnemy(assignedPositions);
-            }
+            _timer = 0f;
+            _isPlaying = false;
         }
+        public void StartGameplay()
+        {
+            if (!_initialized)
+            {
+                return;
+            }
+
+            if (_assignedPositions != null)
+            {
+                SpawnAssignedEnemy(_assignedPositions);
+            }
+
+            _isPlaying = true;
+        }
+
+        public void StopGameplay() => _isPlaying = false;
+
         /// <summary>
         ///     歩兵インスタンスが回収された時のcallback処理。
         /// </summary>
@@ -42,10 +59,12 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
         private int _spawnCount;
         private Vector3[] _spawnPositions;
         private bool _initialized = false;
+        private Transform[] _assignedPositions;
+        private bool _isPlaying = false;
 
         private void Update()
         {
-            if (!_initialized) return;
+            if (!_initialized || !_isPlaying) return;
             if (_spawnCount >= _maxSpawnCount && _maxSpawnCount != -1) return;
 
             _timer += Time.deltaTime;

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyLifeCycle.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Enemy/EnemyLifeCycle.cs
@@ -13,6 +13,7 @@ using KillChord.Runtime.InfraStructure.InGame.Enemy;
 using KillChord.Runtime.InfraStructure.InGame.Mission;
 using KillChord.Runtime.View.InGame.Enemy;
 using KillChord.Runtime.View.InGame.Enemy.AIFacade;
+using KillChord.Runtime.View.InGame.Sequence;
 using KillChord.Runtime.View.InGame.UI;
 using SymphonyFrameWork.System.ServiceLocate;
 using System;
@@ -25,7 +26,7 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
     /// <summary>
     ///     敵の依存関係を構築する。
     /// </summary>
-    public class EnemyLifeCycle : MonoBehaviour
+    public class EnemyLifeCycle : MonoBehaviour, IGameplayControllable
     {
 
         /// <summary>
@@ -83,7 +84,7 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
 
             // Adaptor
             IMusicActionScheduler musicActionScheduler = new MusicSchedulerAdaptor(musicSyncState, musicSyncService);
-            
+
             // UseCase
             EnemyMoveUsecase useCase = new EnemyMoveUsecase(spec, raycastDetectService, attackPositionSearchService);
             EnemyAttackReservationUsecase attackReservationUsecase = new EnemyAttackReservationUsecase(attackMusicSpec, musicActionScheduler);
@@ -104,7 +105,7 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
 
             IHealthHudViewModel viewModel = new HealthHudViewModel(_enemyEntity.CurrentHealth.Value, _enemyEntity.MaxHealth.Value);
             // HP Presenter
-             IHealthHudPresenter healthHudPresenter = new EnemyHealthHudPresenter(_enemyEntity, viewModel, _healthView);
+            IHealthHudPresenter healthHudPresenter = new EnemyHealthHudPresenter(_enemyEntity, viewModel, _healthView);
             _healthHudPresenter = healthHudPresenter;
 
             _lockOnTargetGateway = new LockOnTargetGateway(transform);
@@ -118,7 +119,7 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
             _aiController.On2BeatBefore += _raycastView.StartTrackingWarning;
             _aiController.OnAttack += _raycastView.HideWarning;
             _attackPositionSearchView.Initialize();
-            if(_shellSpawner != null && shellPool != null)
+            if (_shellSpawner != null && shellPool != null)
             {
                 _shellSpawner.Initialize(shellPool);
             }
@@ -178,7 +179,7 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
             }
             _targetManagerController?.Unregister(_lockOnTargetGateway);
             _targetEntityRegistryController?.UnregisterTargetEntity(_lockOnTargetGateway);
-            
+
             _attackReservationUsecase.Deactivate();
             _aiController.Deactivate();
             _healthHudPresenter.Deactivate();
@@ -189,6 +190,52 @@ namespace KillChord.Runtime.Composition.InGame.Enemy
             _releaseCallback?.Invoke(this);
 
         }
+
+        /// <summary>
+        ///    ゲームプレイ開始処理。
+        /// </summary>
+        public void StartGameplay()
+        {
+            if (_behaviorGraphAgent != null)
+            {
+                _behaviorGraphAgent.enabled = true;
+                _behaviorGraphAgent.Restart();
+            }
+
+            if (_navMeshAgent != null && _navMeshAgent.enabled)
+            {
+                _navMeshAgent.isStopped = false;
+            }
+
+            _enemyBattleAIFacade?.StartGameplay();
+            _view?.StartGameplay();
+        }
+
+        /// <summary>
+        ///    ゲームプレイ停止処理。
+        /// </summary>
+        public void StopGameplay()
+        {
+            _attackReservationUsecase?.Deactivate();
+            _aiController?.CancelAttack();
+
+            if (_behaviorGraphAgent != null)
+            {
+                _behaviorGraphAgent.enabled = false;
+            }
+
+            if (_navMeshAgent != null && _navMeshAgent.enabled && _navMeshAgent.isOnNavMesh)
+            {
+                _navMeshAgent.isStopped = true;
+                _navMeshAgent.ResetPath();
+                _navMeshAgent.velocity = Vector3.zero;
+                _navMeshAgent.updateRotation = false;
+            }
+
+            _enemyBattleAIFacade?.StopGameplay();
+            _view?.StopGameplay();
+        }
+
         private System.Action _spawnerCallback;
         private Action<EnemyLifeCycle> _releaseCallback;
 

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Music/MusicSyncInitializer.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Music/MusicSyncInitializer.cs
@@ -2,6 +2,7 @@ using KillChord.Runtime.Adaptor.InGame.Music;
 using KillChord.Runtime.Application.InGame.Music;
 using KillChord.Runtime.Domain.InGame.Music;
 using KillChord.Runtime.View.InGame.Music;
+using KillChord.Runtime.View.InGame.Sequence;
 using KillChord.Runtime.View.Persistent.Music;
 using SymphonyFrameWork.System.ServiceLocate;
 using UnityEngine;
@@ -11,7 +12,7 @@ namespace KillChord.Runtime.Composition.InGame.Music
     /// <summary>
     ///     音楽同期機能の初期化を行うクラス。
     /// </summary>
-    public class MusicSyncInitializer : MonoBehaviour
+    public class MusicSyncInitializer : MonoBehaviour, IGameplayControllable
     {
         /// <summary> 音楽同期コントローラー。 </summary>
         public MusicSyncController MusicSyncController { get; private set; }
@@ -26,19 +27,44 @@ namespace KillChord.Runtime.Composition.InGame.Music
         public void Initialize()
         {
             MusicSyncState = new();
-            var musicPlayer = ServiceLocator.GetInstance<MusicPlayer>();
+            _musicPlayer = ServiceLocator.GetInstance<MusicPlayer>();
             MusicSyncService = new MusicSyncService(new RhythmDefinition(_testBpm, _justTimingThreshold), RhythmJustService.Instance.TriggerJustHit);
             MusicSyncController = new(MusicSyncState, MusicSyncService);
             _musicSyncView.Bind(
-                musicPlayer,
+                _musicPlayer,
                 MusicSyncState,
                 MusicSyncController,
                 _testBpm
             );
 
-            musicPlayer.MusicVM.UpdateMusicCue(_testCue);
             ServiceLocator.RegisterInstance<IMusicSyncService>(MusicSyncService);
             ServiceLocator.RegisterInstance<MusicSyncState>(MusicSyncState);
+        }
+
+        /// <summary>
+        ///　    ゲームプレイを開始し、音楽同期機能を有効にする。
+        /// </summary>
+        public void StartGameplay()
+        {
+            if (_musicPlayer == null)
+            {
+                return;
+            }
+
+            _musicPlayer.MusicVM.UpdateMusicCue(_testCue);
+        }
+
+        /// <summary>
+        ///    ゲームプレイを停止し、音楽同期機能を無効にする。
+        /// </summary>
+        public void StopGameplay()
+        {
+            if (_musicPlayer == null)
+            {
+                return;
+            }
+
+            _musicPlayer.MusicVM.UpdateMusicCue(string.Empty);
         }
 
         [Tooltip("音楽同期View。")]
@@ -50,5 +76,6 @@ namespace KillChord.Runtime.Composition.InGame.Music
         [Tooltip("ジャスト判定の閾値。")]
         [SerializeField] private float _justTimingThreshold;
 
+        private MusicPlayer _musicPlayer;
     }
 }

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Player/PlayerInitializer.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Player/PlayerInitializer.cs
@@ -10,8 +10,6 @@ using KillChord.Runtime.Application.InGame.Camera.Target;
 using KillChord.Runtime.Application.InGame.Music;
 using KillChord.Runtime.Application.InGame.Player;
 using KillChord.Runtime.Application.InGame.Skill;
-using KillChord.Runtime.Composition.InGame.Enemy;
-using KillChord.Runtime.Composition.InGame.Music;
 using KillChord.Runtime.Composition.InGame.UI;
 using KillChord.Runtime.Composition.Persistent.Camera;
 using KillChord.Runtime.Composition.Persistent.Input;
@@ -32,9 +30,6 @@ using KillChord.Runtime.View.Persistent.Input;
 using SymphonyFrameWork.System.ServiceLocate;
 using System.Collections.Generic;
 using UnityEngine;
-
-
-
 
 #if UNITY_EDITOR
 #endif
@@ -97,7 +92,7 @@ namespace KillChord.Runtime.Composition.InGame.Player
             }
 
             MusicSyncState musicSyncState = ServiceLocator.GetInstance<MusicSyncState>();
-            if(musicSyncState == null)
+            if (musicSyncState == null)
             {
                 Debug.LogError($"{nameof(MusicSyncState)}が見つかりません。ServiceLocatorに登録されているか確認してください。", this);
             }

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence.meta
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6bb5e57e96ab4a347a1e4d4b4c97c6c7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGamePlayDirector.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGamePlayDirector.cs
@@ -1,0 +1,64 @@
+using KillChord.Runtime.View.InGame.Sequence;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace KillChord.Runtime.Composition.InGame.Sequence
+{
+    public class InGamePlayDirector : MonoBehaviour, IGameplayControllable
+    {
+        public void StartGameplay()
+        {
+            CacheControllables();
+
+            foreach (var controllable in _gameplayControllables)
+            {
+                controllable?.StartGameplay();
+            }
+        }
+
+        public void StopGameplay()
+        {
+            CacheControllables();
+
+            foreach (var controllable in _gameplayControllables)
+            {
+                controllable?.StopGameplay();
+            }
+        }
+
+        [SerializeField, Header("ゲーム開始と終了の演出に関わるIGameplayControllableを実装したMonoBehaviourリスト")]
+        private MonoBehaviour[] _gamePlayControllableObjects;
+
+        private readonly List<IGameplayControllable> _gameplayControllables = new();
+        private bool _cached;
+
+        /// <summary>
+        ///     シリアライズされた配列から
+        ///     IGameplayControllableを実装しているものを抽出してリストに追加する。
+        /// </summary>
+        private void CacheControllables()
+        {
+            if (_cached)
+            {
+                return;
+            }
+
+            _gameplayControllables.Clear();
+
+            // _gamePlayControllableObjectsから
+            // IGameplayControllableを実装しているものを抽出して_gameplayControllablesに追加する。
+            foreach (var mono in _gamePlayControllableObjects)
+            {
+                if (mono is IGameplayControllable controllable)
+                {
+                    _gameplayControllables.Add(controllable);
+                }
+                else
+                {
+                    Debug.LogWarning($"[InGamePlayDirector] {mono.name} は IGameplayControllable を実装していません。");
+                }
+            }
+            _cached = true;
+        }
+    }
+}

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGamePlayDirector.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGamePlayDirector.cs
@@ -4,8 +4,14 @@ using UnityEngine;
 
 namespace KillChord.Runtime.Composition.InGame.Sequence
 {
+    /// <summary>
+    ///    ゲームプレイの開始と終了の演出を制御するクラス。
+    /// </summary>
     public class InGamePlayDirector : MonoBehaviour, IGameplayControllable
     {
+        /// <summary>
+        ///     ゲームプレイの開始演出を開始する。
+        /// </summary>
         public void StartGameplay()
         {
             CacheControllables();
@@ -16,6 +22,9 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
             }
         }
 
+        /// <summary>
+        ///     ゲームプレイの終了演出を開始する。
+        /// </summary>
         public void StopGameplay()
         {
             CacheControllables();
@@ -26,9 +35,14 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
             }
         }
 
+        /// <summary>
+        ///     ゲームプレイの開始と終了の演出に関わるIGameplayControllableを実装したMonoBehaviourを追加する。
+        ///     これはステージシーンなどに配置されたIGameplayControllableを実装したMonoBehaviourをInGamePlayDirectorに紐づけるためのメソッドです。
+        /// </summary>
+        /// <param name="controllable">追加するIGameplayControllableを実装したMonoBehaviour</param>
         public void AddGamePlayControllable(IGameplayControllable controllable)
         {
-            if(controllable == null)
+            if (controllable == null)
             {
                 Debug.LogWarning("[InGamePlayDirector] 追加しようとした IGameplayControllable が null です。");
                 return;

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGamePlayDirector.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGamePlayDirector.cs
@@ -26,6 +26,22 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
             }
         }
 
+        public void AddGamePlayControllable(IGameplayControllable controllable)
+        {
+            if(controllable == null)
+            {
+                Debug.LogWarning("[InGamePlayDirector] 追加しようとした IGameplayControllable が null です。");
+                return;
+            }
+
+            CacheControllables();
+
+            if (!_gameplayControllables.Contains(controllable))
+            {
+                _gameplayControllables.Add(controllable);
+            }
+        }
+
         [SerializeField, Header("ゲーム開始と終了の演出に関わるIGameplayControllableを実装したMonoBehaviourリスト")]
         private MonoBehaviour[] _gamePlayControllableObjects;
 
@@ -49,6 +65,12 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
             // IGameplayControllableを実装しているものを抽出して_gameplayControllablesに追加する。
             foreach (var mono in _gamePlayControllableObjects)
             {
+                if (mono == null)
+                {
+                    Debug.LogWarning("[InGamePlayDirector] 制御対象が未設定です。", this);
+                    continue;
+                }
+
                 if (mono is IGameplayControllable controllable)
                 {
                     _gameplayControllables.Add(controllable);

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGamePlayDirector.cs.meta
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGamePlayDirector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24a950994675c7447bfa2f5d10029458

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs
@@ -69,7 +69,7 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
         public async Awaitable GameOverAsync(CancellationToken cancellationToken)
         {
             _gameplayControllable.StopGameplay();
-            _stageResultUIView.SetGameOverMessage();
+            _stageResultUIView?.SetGameOverMessage();
 
             if (_stageSequenceView != null)
             {

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs
@@ -1,0 +1,60 @@
+using KillChord.Runtime.View.InGame.Sequence;
+using System.Threading;
+using UnityEngine;
+
+namespace KillChord.Runtime.Composition.InGame.Sequence
+{
+    public class InGameSequenceDirector
+    {
+        public InGameSequenceDirector(
+            StageSequenceView stageSequenceView, 
+            StageResultUIView stageResultUIView, 
+            IGameplayControllable gameplayControllable)
+        {
+            _stageSequenceView = stageSequenceView;
+            _stageResultUIView = stageResultUIView;
+            _gameplayControllable = gameplayControllable;
+        }
+
+        public async Awaitable StartAsync(CancellationToken cancellationToken)
+        {
+            _gameplayControllable.StopGameplay();
+            _stageResultUIView?.Hide();
+
+            if(_stageSequenceView != null)
+            {
+                await _stageSequenceView.PlayStageStartAsync(cancellationToken);
+            }
+
+            _gameplayControllable.StartGameplay();
+        }
+
+        public async Awaitable ClearAsync(CancellationToken cancellationToken)
+        {
+            _gameplayControllable.StopGameplay();
+
+            if (_stageSequenceView != null)
+            {
+                await _stageSequenceView.PlayStageClearAsync(cancellationToken);
+            }
+
+            _stageResultUIView?.ShowClear();
+        }
+
+        public async Awaitable GameOverAsync(CancellationToken cancellationToken)
+        {
+            _gameplayControllable.StopGameplay();
+
+            if (_stageSequenceView != null)
+            {
+                await _stageSequenceView.PlayGameOverAsync(cancellationToken);
+            }
+
+            _stageResultUIView?.ShowGameOver();
+        }
+
+        private readonly StageSequenceView _stageSequenceView;
+        private readonly StageResultUIView _stageResultUIView;
+        private readonly IGameplayControllable _gameplayControllable;
+    }
+}

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs
@@ -4,11 +4,20 @@ using UnityEngine;
 
 namespace KillChord.Runtime.Composition.InGame.Sequence
 {
+    /// <summary>
+    ///     ゲームプレイの開始と終了の演出を制御するクラス。
+    /// </summary>
     public class InGameSequenceDirector
     {
+        /// <summary>
+        ///    コンストラクタ。
+        /// </summary>
+        /// <param name="stageSequenceView"> ステージのシーケンスを表示するビュー。 </param>
+        /// <param name="stageResultUIView"> ステージの結果を表示するビュー。 </param>
+        /// <param name="gameplayControllable"> ゲームプレイの開始と終了を制御するオブジェクト。 </param>
         public InGameSequenceDirector(
-            StageSequenceView stageSequenceView, 
-            StageResultUIView stageResultUIView, 
+            StageSequenceView stageSequenceView,
+            StageResultUIView stageResultUIView,
             IGameplayControllable gameplayControllable)
         {
             _stageSequenceView = stageSequenceView;
@@ -16,6 +25,11 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
             _gameplayControllable = gameplayControllable;
         }
 
+        /// <summary>
+        ///    ゲームプレイの開始演出を開始する。
+        /// </summary>
+        /// <param name="cancellationToken"> キャンセルトークン。 </param>
+        /// <returns> 非同期操作の完了を表すAwaitable。 </returns>
         public async Awaitable StartAsync(CancellationToken cancellationToken)
         {
             _gameplayControllable.StopGameplay();
@@ -30,6 +44,11 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
             _gameplayControllable.StartGameplay();
         }
 
+        /// <summary>
+        ///     ゲームプレイのクリア演出を開始する。
+        /// </summary>
+        /// <param name="cancellationToken"> キャンセルトークン。 </param>
+        /// <returns> 非同期操作の完了を表すAwaitable。 </returns>
         public async Awaitable ClearAsync(CancellationToken cancellationToken)
         {
             _gameplayControllable.StopGameplay();
@@ -42,7 +61,11 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
 
             _stageResultUIView?.ShowClear();
         }
-
+        /// <summary>
+        ///     ゲームプレイのゲームオーバー演出を開始する。
+        /// </summary>
+        /// <param name="cancellationToken"> キャンセルトークン。 </param>
+        /// <returns> 非同期操作の完了を表すAwaitable。 </returns>
         public async Awaitable GameOverAsync(CancellationToken cancellationToken)
         {
             _gameplayControllable.StopGameplay();

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs
@@ -20,8 +20,9 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
         {
             _gameplayControllable.StopGameplay();
             _stageResultUIView?.Hide();
+            _stageResultUIView?.SetStageStartMessage();
 
-            if(_stageSequenceView != null)
+            if (_stageSequenceView != null)
             {
                 await _stageSequenceView.PlayStageStartAsync(cancellationToken);
             }
@@ -32,6 +33,7 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
         public async Awaitable ClearAsync(CancellationToken cancellationToken)
         {
             _gameplayControllable.StopGameplay();
+            _stageResultUIView?.SetClearMessage();
 
             if (_stageSequenceView != null)
             {
@@ -44,6 +46,7 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
         public async Awaitable GameOverAsync(CancellationToken cancellationToken)
         {
             _gameplayControllable.StopGameplay();
+            _stageResultUIView.SetGameOverMessage();
 
             if (_stageSequenceView != null)
             {

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs.meta
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InGameSequenceDirector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 81d4940f98ebaf54195ef7da39881a76

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InputGamePlayControllable.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InputGamePlayControllable.cs
@@ -1,0 +1,60 @@
+using KillChord.Runtime.Composition.Persistent.Input;
+using KillChord.Runtime.View.InGame.Sequence;
+using KillChord.Runtime.View.Persistent.Input;
+using SymphonyFrameWork.System.ServiceLocate;
+using UnityEngine;
+
+namespace KillChord.Runtime.Composition.InGame.Sequence
+{
+    public class InputGamePlayControllable : MonoBehaviour, IGameplayControllable
+    {
+        public InputGamePlayControllable(InputComposition inputComposition)
+        {
+            _inputComposition = inputComposition;
+        }
+
+        public void StartGameplay()
+        {
+            InputComposition inputComposition = GetInputComposition();
+
+            if (inputComposition == null)
+            {
+                return;
+            }
+
+            inputComposition.GetInputMapController.EnableOnly(InputMapNames.InGame);
+        }
+
+        public void StopGameplay()
+        {
+            InputComposition inputComposition = GetInputComposition();
+
+            if (inputComposition == null)
+            {
+                return;
+            }
+
+            // ゲームプレイ停止時は、Common(設定やポーズ)のみを有効化して他のマップは無効化する。
+            inputComposition.GetInputMapController.EnableOnly(InputMapNames.Common);
+        }
+
+        private InputComposition GetInputComposition()
+        {
+            if (_inputComposition != null)
+            {
+                return _inputComposition;
+            }
+
+            _inputComposition = ServiceLocator.GetInstance<InputComposition>();
+
+            if (_inputComposition == null)
+            {
+                Debug.LogError("[InputGamePlayControllable] InputComposition の取得に失敗しました。", this);
+            }
+
+            return _inputComposition;
+        }
+
+        private InputComposition _inputComposition;
+    }
+}

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InputGamePlayControllable.cs
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InputGamePlayControllable.cs
@@ -6,13 +6,14 @@ using UnityEngine;
 
 namespace KillChord.Runtime.Composition.InGame.Sequence
 {
+    /// <summary>
+    ///     入力のゲームプレイ制御クラス。
+    /// </summary>
     public class InputGamePlayControllable : MonoBehaviour, IGameplayControllable
     {
-        public InputGamePlayControllable(InputComposition inputComposition)
-        {
-            _inputComposition = inputComposition;
-        }
-
+        /// <summary>
+        ///     ゲームプレイ開始時の処理。
+        /// </summary>
         public void StartGameplay()
         {
             InputComposition inputComposition = GetInputComposition();
@@ -25,6 +26,9 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
             inputComposition.GetInputMapController.EnableOnly(InputMapNames.InGame);
         }
 
+        /// <summary>
+        ///     ゲームプレイ停止時の処理。
+        /// </summary>
         public void StopGameplay()
         {
             InputComposition inputComposition = GetInputComposition();
@@ -38,6 +42,10 @@ namespace KillChord.Runtime.Composition.InGame.Sequence
             inputComposition.GetInputMapController.EnableOnly(InputMapNames.Common);
         }
 
+        /// <summary>
+        ///    InputComposition を取得するためのヘルパーメソッド。
+        /// </summary>
+        /// <returns></returns>
         private InputComposition GetInputComposition()
         {
             if (_inputComposition != null)

--- a/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InputGamePlayControllable.cs.meta
+++ b/Assets/Scripts/Runtime/6.Composition/InGame/Sequence/InputGamePlayControllable.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 59490565deb1bfd4894ea9dd1eaa5ce1


### PR DESCRIPTION
広い範囲触ってるので注意

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ステージ開始・クリア・ゲームオーバーの演出フローを追加・統合し、演出再生とゲーム再生の開始/停止を一元管理します。
  * 再生/停止を切り替える汎用インターフェースとそれを伝播する制御機能を追加しました。
  * ミッション終了を通知するイベントを追加しました。

* **UI**
  * ステージ結果画面の表示／非表示とメッセージ切替を行うUIを追加しました。

* **Animation**
  * ステージ開始・クリア・ゲームオーバー用のタイムラインアニメーションを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->