### PR TITLE
出力先のディレクトリ指定を環境変数で指定可能に変更

### DIFF
--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -97,21 +97,23 @@ jobs:
 
       - name: Check Build Output
         run: |
-          if (Test-Path "Builds") {
-            Write-Host "Build artifacts found in Builds directory"
-            Get-ChildItem -Path "Builds" -Recurse | ForEach-Object { Write-Host $_.FullName }
+          $BuildDir = if ($env:UNITY_BUILD_OUTPUT_DIR) { $env:UNITY_BUILD_OUTPUT_DIR } else { "Builds" }
+          if (Test-Path $BuildDir) {
+            Write-Host "Build artifacts found in $BuildDir directory"
+            Get-ChildItem -Path $BuildDir -Recurse | ForEach-Object { Write-Host $_.FullName }
           } else {
-            Write-Host "WARNING: No Builds directory found"
+            Write-Host "WARNING: No $BuildDir directory found"
           }
         shell: powershell
 
       - name: Zip Build Artifacts
         run: |
-          if (Test-Path "Builds") {
-            Compress-Archive -Path Builds\* -DestinationPath Builds.zip
+          $BuildDir = if ($env:UNITY_BUILD_OUTPUT_DIR) { $env:UNITY_BUILD_OUTPUT_DIR } else { "Builds" }
+          if (Test-Path $BuildDir) {
+            Compress-Archive -Path "$BuildDir\*" -DestinationPath Builds.zip
             Write-Host "Build artifacts compressed successfully"
           } else {
-            Write-Host "ERROR: Builds directory not found, cannot create archive"
+            Write-Host "ERROR: $BuildDir directory not found, cannot create archive"
             exit 1
           }
         shell: powershell

--- a/.github/workflows/BuildAndRelease.yml
+++ b/.github/workflows/BuildAndRelease.yml
@@ -58,6 +58,12 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 120  # ビルド処理が長くなる可能性があるため、タイムアウトを設定
     environment: 'AutoBuildAndRelease'
+    # ジョブ全体で利用する環境変数（必要に応じてリポジトリ Secrets に設定）
+    env:
+      GOOGLE_DRIVE_API_KEY: ${{ secrets.GOOGLE_DRIVE_API_KEY }}
+      GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
+      # UNITY_BUILD_OUTPUT_DIR を設定すると出力先を上書きできます（省略時はプロジェクト内 Builds フォルダを使用）
+      UNITY_BUILD_OUTPUT_DIR: ${{ secrets.UNITY_BUILD_OUTPUT_DIR }}
 
     steps:
       - name: Checkout Repository
@@ -79,9 +85,6 @@ jobs:
         env:
           # Unity 実行ファイルパスを GitHub Secrets から取得
           UNITY_EXE_PATH: ${{ secrets.UNITY_EXE_PATH }}
-          # Google Drive API認証情報（GitHub Secrets から取得）
-          GOOGLE_DRIVE_API_KEY: ${{ secrets.GOOGLE_DRIVE_API_KEY }}
-          GOOGLE_DRIVE_FOLDER_ID: ${{ secrets.GOOGLE_DRIVE_FOLDER_ID }}
 
       - name: Upload Unity Log
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02

--- a/Assets/Editor/Scripts/AutoBuilder/AutoBuilder.cs
+++ b/Assets/Editor/Scripts/AutoBuilder/AutoBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using UnityEditor;
@@ -79,7 +80,26 @@ namespace KillChord.Editor.AutoBuilder
         /// <returns>ビルド成功時は true、失敗時は false</returns>
         private static bool ExecuteBuildForProfile(BuildProfile profile)
         {
-            string outputDir = Path.Combine(Application.dataPath, "../Builds", profile.name);
+            // 環境変数 UNITY_BUILD_OUTPUT_DIR が指定されていれば優先して使用する
+            string envDir = Environment.GetEnvironmentVariable("UNITY_BUILD_OUTPUT_DIR");
+            string baseOutputDir;
+            if (!string.IsNullOrEmpty(envDir))
+            {
+                baseOutputDir = envDir;
+                Debug.Log($"[AutoBuilder] Using UNITY_BUILD_OUTPUT_DIR from environment: {baseOutputDir}");
+            }
+            else
+            {
+                baseOutputDir = Path.Combine(Application.dataPath, "../Builds");
+            }
+
+            // 相対パスが指定されている場合はプロジェクトルート基準で絶対化する
+            if (!Path.IsPathRooted(baseOutputDir))
+            {
+                baseOutputDir = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), baseOutputDir));
+            }
+
+            string outputDir = Path.Combine(baseOutputDir, profile.name);
             if (!Directory.Exists(outputDir))
             {
                 Directory.CreateDirectory(outputDir);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ビルド出力ディレクトリを環境変数で設定できるようになりました。
  * GitHub Actionsワークフローの環境変数設定を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->